### PR TITLE
Add Network API v10.4.57 support (switching: LAG, MC-LAG, switch stacks)

### DIFF
--- a/src/UniFi.Net.Network/INetworkClient.cs
+++ b/src/UniFi.Net.Network/INetworkClient.cs
@@ -331,6 +331,70 @@ public interface INetworkClient
 
     #endregion
 
+    #region Switching
+
+    /// <summary>
+    /// Gets a list of link aggregation groups (LAGs) for a site.
+    /// </summary>
+    /// <param name="siteId">The site ID.</param>
+    /// <param name="filter">A filter expression.</param>
+    /// <param name="offset">The number of LAGs to offset.</param>
+    /// <param name="limit">The maximum number of LAGs to return (max 200).</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A paged response of LAGs.</returns>
+    Task<PagedResponse<Lag>> ListLags(Guid siteId, IFilter? filter = null, int? offset = null, int? limit = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a specific link aggregation group (LAG) by its ID.
+    /// </summary>
+    /// <param name="siteId">The site ID.</param>
+    /// <param name="lagId">The LAG ID.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>LAG details.</returns>
+    Task<Lag> GetLag(Guid siteId, Guid lagId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a list of multi-chassis LAG (MC-LAG) domains for a site.
+    /// </summary>
+    /// <param name="siteId">The site ID.</param>
+    /// <param name="filter">A filter expression.</param>
+    /// <param name="offset">The number of MC-LAG domains to offset.</param>
+    /// <param name="limit">The maximum number of MC-LAG domains to return (max 200).</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A paged response of MC-LAG domains.</returns>
+    Task<PagedResponse<McLagDomain>> ListMcLagDomains(Guid siteId, IFilter? filter = null, int? offset = null, int? limit = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a specific multi-chassis LAG (MC-LAG) domain by its ID.
+    /// </summary>
+    /// <param name="siteId">The site ID.</param>
+    /// <param name="mcLagDomainId">The MC-LAG domain ID.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>MC-LAG domain details.</returns>
+    Task<McLagDomain> GetMcLagDomain(Guid siteId, Guid mcLagDomainId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a list of switch stacks for a site.
+    /// </summary>
+    /// <param name="siteId">The site ID.</param>
+    /// <param name="filter">A filter expression.</param>
+    /// <param name="offset">The number of switch stacks to offset.</param>
+    /// <param name="limit">The maximum number of switch stacks to return (max 200).</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A paged response of switch stacks.</returns>
+    Task<PagedResponse<SwitchStack>> ListSwitchStacks(Guid siteId, IFilter? filter = null, int? offset = null, int? limit = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a specific switch stack by its ID.
+    /// </summary>
+    /// <param name="siteId">The site ID.</param>
+    /// <param name="switchStackId">The switch stack ID.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>Switch stack details.</returns>
+    Task<SwitchStack> GetSwitchStack(Guid siteId, Guid switchStackId, CancellationToken cancellationToken = default);
+
+    #endregion
+
     #region Firewall Zones
 
     /// <summary>

--- a/src/UniFi.Net.Network/Models/Lag.cs
+++ b/src/UniFi.Net.Network/Models/Lag.cs
@@ -1,0 +1,66 @@
+using System.Text.Json.Serialization;
+using UniFi.Net.Serialization;
+
+namespace UniFi.Net.Network.Models;
+
+/// <summary>
+/// The type of a link aggregation group (LAG).
+/// </summary>
+[JsonConverter(typeof(SnakeCaseEnumConverter))]
+public enum LagType
+{
+    /// <summary>
+    /// A LAG local to a single device.
+    /// </summary>
+    Local = 0,
+
+    /// <summary>
+    /// A multi-chassis LAG spanning the devices of an MC-LAG domain.
+    /// </summary>
+    MultiChassis = 1,
+
+    /// <summary>
+    /// A LAG spanning the members of a switch stack.
+    /// </summary>
+    SwitchStack = 2,
+}
+
+/// <summary>
+/// Represents a link aggregation group (LAG).
+/// </summary>
+/// <param name="Id">The unique identifier of the LAG.</param>
+/// <param name="Type">The type of the LAG.</param>
+/// <param name="Members">The member ports that make up the LAG.</param>
+/// <param name="Metadata">The metadata for the LAG.</param>
+/// <param name="McLagDomainId">The identifier of the owning MC-LAG domain. Set only when <see cref="Type"/> is <see cref="LagType.MultiChassis"/>.</param>
+/// <param name="SwitchStackId">The identifier of the owning switch stack. Set only when <see cref="Type"/> is <see cref="LagType.SwitchStack"/>.</param>
+public record Lag(
+    Guid Id,
+    LagType Type,
+    IReadOnlyList<LagMember> Members,
+    ResourceMetadata Metadata,
+    Guid? McLagDomainId,
+    Guid? SwitchStackId
+);
+
+/// <summary>
+/// Represents a member of a link aggregation group.
+/// </summary>
+/// <param name="DeviceId">The unique identifier of the device contributing the ports.</param>
+/// <param name="PortIdxs">The indices of the ports that participate in the LAG.</param>
+public record LagMember(
+    Guid DeviceId,
+    IReadOnlyList<int> PortIdxs
+);
+
+/// <summary>
+/// Represents a link aggregation group as nested within an MC-LAG domain or switch stack.
+/// </summary>
+/// <param name="Id">The unique identifier of the LAG.</param>
+/// <param name="Members">The member ports that make up the LAG.</param>
+/// <param name="Metadata">The metadata for the LAG.</param>
+public record LagSummary(
+    Guid Id,
+    IReadOnlyList<LagMember> Members,
+    ResourceMetadata Metadata
+);

--- a/src/UniFi.Net.Network/Models/McLagDomain.cs
+++ b/src/UniFi.Net.Network/Models/McLagDomain.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+using UniFi.Net.Serialization;
+
+namespace UniFi.Net.Network.Models;
+
+/// <summary>
+/// The role of a peer within a multi-chassis LAG (MC-LAG) domain.
+/// </summary>
+[JsonConverter(typeof(SnakeCaseEnumConverter))]
+public enum McLagPeerRole
+{
+    /// <summary>
+    /// The top peer of the MC-LAG domain.
+    /// </summary>
+    Top = 0,
+
+    /// <summary>
+    /// The bottom peer of the MC-LAG domain.
+    /// </summary>
+    Bottom = 1,
+}
+
+/// <summary>
+/// Represents a multi-chassis LAG (MC-LAG) domain.
+/// </summary>
+/// <param name="Id">The unique identifier of the MC-LAG domain.</param>
+/// <param name="Name">The name of the MC-LAG domain.</param>
+/// <param name="Metadata">The metadata for the MC-LAG domain.</param>
+/// <param name="Lags">The LAGs that belong to the MC-LAG domain.</param>
+/// <param name="Peers">The peer devices that form the MC-LAG domain.</param>
+public record McLagDomain(
+    Guid Id,
+    string Name,
+    ResourceMetadata Metadata,
+    IReadOnlyList<LagSummary> Lags,
+    IReadOnlyList<McLagPeer> Peers
+);
+
+/// <summary>
+/// Represents a peer device within an MC-LAG domain.
+/// </summary>
+/// <param name="DeviceId">The unique identifier of the peer device.</param>
+/// <param name="LinkPortIdxs">The indices of the ports forming the peer link.</param>
+/// <param name="Role">The role of the peer within the MC-LAG domain.</param>
+public record McLagPeer(
+    Guid DeviceId,
+    IReadOnlyList<int> LinkPortIdxs,
+    McLagPeerRole Role
+);

--- a/src/UniFi.Net.Network/Models/SwitchStack.cs
+++ b/src/UniFi.Net.Network/Models/SwitchStack.cs
@@ -1,0 +1,25 @@
+namespace UniFi.Net.Network.Models;
+
+/// <summary>
+/// Represents a switch stack.
+/// </summary>
+/// <param name="Id">The unique identifier of the switch stack.</param>
+/// <param name="Name">The name of the switch stack.</param>
+/// <param name="Metadata">The metadata for the switch stack.</param>
+/// <param name="Lags">The LAGs that belong to the switch stack.</param>
+/// <param name="Members">The devices that are members of the switch stack.</param>
+public record SwitchStack(
+    Guid Id,
+    string Name,
+    ResourceMetadata Metadata,
+    IReadOnlyList<LagSummary> Lags,
+    IReadOnlyList<SwitchStackMember> Members
+);
+
+/// <summary>
+/// Represents a member device of a switch stack.
+/// </summary>
+/// <param name="DeviceId">The unique identifier of the member device.</param>
+public record SwitchStackMember(
+    Guid DeviceId
+);

--- a/src/UniFi.Net.Network/Models/WifiBroadcast.cs
+++ b/src/UniFi.Net.Network/Models/WifiBroadcast.cs
@@ -57,6 +57,8 @@ public record WifiBroadcastSummary(
 /// <param name="ClientIsolationEnabled">Indicates if client isolation is enabled.</param>
 /// <param name="HideName">Indicates if the SSID name is hidden.</param>
 /// <param name="UapsdEnabled">Indicates if U-APSD is enabled.</param>
+/// <param name="Channel2gLockedTo6">Indicates if the 2.4 GHz channel is locked to channel 6.</param>
+/// <param name="DtimPeriod2gLockedTo3">Indicates if the 2.4 GHz DTIM period is locked to 3.</param>
 public record WifiBroadcast(
     Guid Id,
     string Name,
@@ -69,7 +71,9 @@ public record WifiBroadcast(
     bool? MulticastToUnicastConversionEnabled,
     bool? ClientIsolationEnabled,
     bool? HideName,
-    bool? UapsdEnabled
+    bool? UapsdEnabled,
+    bool? Channel2gLockedTo6 = null,
+    bool? DtimPeriod2gLockedTo3 = null
 );
 
 /// <summary>

--- a/src/UniFi.Net.Network/NetworkClient.Switching.cs
+++ b/src/UniFi.Net.Network/NetworkClient.Switching.cs
@@ -1,0 +1,58 @@
+using UniFi.Net.Network.Filters;
+using UniFi.Net.Network.Models;
+
+namespace UniFi.Net.Network;
+
+public partial class NetworkClient
+{
+    /// <inheritdoc />
+    public Task<PagedResponse<Lag>> ListLags(Guid siteId, IFilter? filter = null, int? offset = null, int? limit = null, CancellationToken cancellationToken = default)
+    {
+        string path = $"{PathPrefix}sites/{siteId}/switching/lags";
+        string query = BuildPagingQuery(filter, offset, limit);
+
+        return GetFromJsonAsync<PagedResponse<Lag>>(path + query, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<Lag> GetLag(Guid siteId, Guid lagId, CancellationToken cancellationToken = default)
+    {
+        string path = $"{PathPrefix}sites/{siteId}/switching/lags/{lagId}";
+
+        return GetFromJsonAsync<Lag>(path, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<PagedResponse<McLagDomain>> ListMcLagDomains(Guid siteId, IFilter? filter = null, int? offset = null, int? limit = null, CancellationToken cancellationToken = default)
+    {
+        string path = $"{PathPrefix}sites/{siteId}/switching/mc-lag-domains";
+        string query = BuildPagingQuery(filter, offset, limit);
+
+        return GetFromJsonAsync<PagedResponse<McLagDomain>>(path + query, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<McLagDomain> GetMcLagDomain(Guid siteId, Guid mcLagDomainId, CancellationToken cancellationToken = default)
+    {
+        string path = $"{PathPrefix}sites/{siteId}/switching/mc-lag-domains/{mcLagDomainId}";
+
+        return GetFromJsonAsync<McLagDomain>(path, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<PagedResponse<SwitchStack>> ListSwitchStacks(Guid siteId, IFilter? filter = null, int? offset = null, int? limit = null, CancellationToken cancellationToken = default)
+    {
+        string path = $"{PathPrefix}sites/{siteId}/switching/switch-stacks";
+        string query = BuildPagingQuery(filter, offset, limit);
+
+        return GetFromJsonAsync<PagedResponse<SwitchStack>>(path + query, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task<SwitchStack> GetSwitchStack(Guid siteId, Guid switchStackId, CancellationToken cancellationToken = default)
+    {
+        string path = $"{PathPrefix}sites/{siteId}/switching/switch-stacks/{switchStackId}";
+
+        return GetFromJsonAsync<SwitchStack>(path, cancellationToken);
+    }
+}

--- a/src/UniFi.Net.Network/Requests/CreateWifiBroadcastRequest.cs
+++ b/src/UniFi.Net.Network/Requests/CreateWifiBroadcastRequest.cs
@@ -11,11 +11,15 @@ namespace UniFi.Net.Network;
 /// <param name="Network">The network configuration.</param>
 /// <param name="SecurityConfiguration">The security configuration.</param>
 /// <param name="BroadcastingDeviceFilter">The broadcasting device filter.</param>
+/// <param name="Channel2gLockedTo6">Indicates if the 2.4 GHz channel is locked to channel 6.</param>
+/// <param name="DtimPeriod2gLockedTo3">Indicates if the 2.4 GHz DTIM period is locked to 3.</param>
 public record CreateWifiBroadcastRequest(
     string Name,
     WifiBroadcastType Type,
     bool Enabled,
     WifiBroadcastNetwork? Network = null,
     WifiBroadcastSecurity? SecurityConfiguration = null,
-    WifiBroadcastDeviceFilter? BroadcastingDeviceFilter = null
+    WifiBroadcastDeviceFilter? BroadcastingDeviceFilter = null,
+    bool? Channel2gLockedTo6 = null,
+    bool? DtimPeriod2gLockedTo3 = null
 );

--- a/src/UniFi.Net.Network/Requests/UpdateWifiBroadcastRequest.cs
+++ b/src/UniFi.Net.Network/Requests/UpdateWifiBroadcastRequest.cs
@@ -11,11 +11,15 @@ namespace UniFi.Net.Network;
 /// <param name="Network">The network configuration.</param>
 /// <param name="SecurityConfiguration">The security configuration.</param>
 /// <param name="BroadcastingDeviceFilter">The broadcasting device filter.</param>
+/// <param name="Channel2gLockedTo6">Indicates if the 2.4 GHz channel is locked to channel 6.</param>
+/// <param name="DtimPeriod2gLockedTo3">Indicates if the 2.4 GHz DTIM period is locked to 3.</param>
 public record UpdateWifiBroadcastRequest(
     string Name,
     WifiBroadcastType Type,
     bool Enabled,
     WifiBroadcastNetwork? Network = null,
     WifiBroadcastSecurity? SecurityConfiguration = null,
-    WifiBroadcastDeviceFilter? BroadcastingDeviceFilter = null
+    WifiBroadcastDeviceFilter? BroadcastingDeviceFilter = null,
+    bool? Channel2gLockedTo6 = null,
+    bool? DtimPeriod2gLockedTo3 = null
 );

--- a/src/UniFi.Net.Network/UniFi.Net.Network.csproj
+++ b/src/UniFi.Net.Network/UniFi.Net.Network.csproj
@@ -21,7 +21,7 @@
     <Copyright>© Andrew McLachlan 2025</Copyright>
     <Description>UniFi.Net is a .NET client library for interacting with Ubiquiti UniFi devices.</Description>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>ubiqiti;unifi;network</PackageTags>

--- a/tests/UniFi.Net.Network.Tests/SwitchingModelTests.cs
+++ b/tests/UniFi.Net.Network.Tests/SwitchingModelTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using UniFi.Net.Network.Models;
+
+namespace UniFi.Net.Network.Tests;
+
+[Trait("Category", "Unit")]
+public class SwitchingModelTests
+{
+    // Mirrors the options used by the client's ReadFromJsonAsync<T> (camelCase, case-insensitive).
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Given a paged LAG response containing all three discriminator values,
+    /// When it is deserialized,
+    /// Then each element maps to the correct <see cref="LagType"/> and populates only the matching type-specific identifier.
+    /// </summary>
+    [Fact]
+    public void ListLags_DeserializesFlattenedUnion()
+    {
+        const string json = """
+        {
+          "offset": 0,
+          "limit": 25,
+          "count": 3,
+          "totalCount": 3,
+          "data": [
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "type": "LOCAL",
+              "members": [ { "deviceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "portIdxs": [1, 2] } ],
+              "metadata": { "origin": "USER_DEFINED", "configurable": true }
+            },
+            {
+              "id": "22222222-2222-2222-2222-222222222222",
+              "type": "MULTI_CHASSIS",
+              "members": [ { "deviceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "portIdxs": [3] } ],
+              "metadata": { "origin": "SYSTEM_DEFINED", "configurable": false },
+              "mcLagDomainId": "dddddddd-dddd-dddd-dddd-dddddddddddd"
+            },
+            {
+              "id": "33333333-3333-3333-3333-333333333333",
+              "type": "SWITCH_STACK",
+              "members": [ { "deviceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "portIdxs": [4, 5, 6] } ],
+              "metadata": { "origin": "USER_DEFINED", "configurable": true },
+              "switchStackId": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+            }
+          ]
+        }
+        """;
+
+        var result = JsonSerializer.Deserialize<PagedResponse<Lag>>(json, Options);
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result!.Data.Count);
+
+        var local = result.Data[0];
+        Assert.Equal(LagType.Local, local.Type);
+        Assert.Null(local.McLagDomainId);
+        Assert.Null(local.SwitchStackId);
+        Assert.Equal(new[] { 1, 2 }, local.Members[0].PortIdxs);
+        Assert.Equal(MetadataOrigin.UserDefined, local.Metadata.Origin);
+
+        var mcLag = result.Data[1];
+        Assert.Equal(LagType.MultiChassis, mcLag.Type);
+        Assert.Equal(Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"), mcLag.McLagDomainId);
+        Assert.Null(mcLag.SwitchStackId);
+
+        var stackLag = result.Data[2];
+        Assert.Equal(LagType.SwitchStack, stackLag.Type);
+        Assert.Equal(Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"), stackLag.SwitchStackId);
+        Assert.Null(stackLag.McLagDomainId);
+    }
+
+    /// <summary>
+    /// Given an MC-LAG domain payload,
+    /// When it is deserialized,
+    /// Then its nested LAGs and peers (including peer roles) map correctly.
+    /// </summary>
+    [Fact]
+    public void GetMcLagDomain_DeserializesPeersAndLags()
+    {
+        const string json = """
+        {
+          "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+          "name": "Domain A",
+          "metadata": { "origin": "USER_DEFINED", "configurable": true },
+          "lags": [
+            {
+              "id": "22222222-2222-2222-2222-222222222222",
+              "members": [ { "deviceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "portIdxs": [3] } ],
+              "metadata": { "origin": "SYSTEM_DEFINED", "configurable": false }
+            }
+          ],
+          "peers": [
+            { "deviceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "linkPortIdxs": [9, 10], "role": "TOP" },
+            { "deviceId": "ffffffff-ffff-ffff-ffff-ffffffffffff", "linkPortIdxs": [9, 10], "role": "BOTTOM" }
+          ]
+        }
+        """;
+
+        var domain = JsonSerializer.Deserialize<McLagDomain>(json, Options);
+
+        Assert.NotNull(domain);
+        Assert.Equal("Domain A", domain!.Name);
+        Assert.Single(domain.Lags);
+        Assert.Equal(new[] { 3 }, domain.Lags[0].Members[0].PortIdxs);
+        Assert.Equal(2, domain.Peers.Count);
+        Assert.Equal(McLagPeerRole.Top, domain.Peers[0].Role);
+        Assert.Equal(McLagPeerRole.Bottom, domain.Peers[1].Role);
+        Assert.Equal(new[] { 9, 10 }, domain.Peers[0].LinkPortIdxs);
+    }
+
+    /// <summary>
+    /// Given a switch stack payload,
+    /// When it is deserialized,
+    /// Then its member devices and nested LAGs map correctly.
+    /// </summary>
+    [Fact]
+    public void GetSwitchStack_DeserializesMembersAndLags()
+    {
+        const string json = """
+        {
+          "id": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+          "name": "Stack 1",
+          "metadata": { "origin": "USER_DEFINED", "configurable": true },
+          "lags": [
+            {
+              "id": "33333333-3333-3333-3333-333333333333",
+              "members": [ { "deviceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "portIdxs": [4, 5] } ],
+              "metadata": { "origin": "USER_DEFINED", "configurable": true }
+            }
+          ],
+          "members": [
+            { "deviceId": "cccccccc-cccc-cccc-cccc-cccccccccccc" },
+            { "deviceId": "99999999-9999-9999-9999-999999999999" }
+          ]
+        }
+        """;
+
+        var stack = JsonSerializer.Deserialize<SwitchStack>(json, Options);
+
+        Assert.NotNull(stack);
+        Assert.Equal("Stack 1", stack!.Name);
+        Assert.Equal(2, stack.Members.Count);
+        Assert.Equal(Guid.Parse("99999999-9999-9999-9999-999999999999"), stack.Members[1].DeviceId);
+        Assert.Single(stack.Lags);
+        Assert.Equal(new[] { 4, 5 }, stack.Lags[0].Members[0].PortIdxs);
+    }
+
+    /// <summary>
+    /// Given a WiFi broadcast payload that includes the v10.4.57 2.4 GHz lock fields,
+    /// When it is deserialized,
+    /// Then the new optional boolean fields are populated.
+    /// </summary>
+    [Fact]
+    public void WifiBroadcast_DeserializesNewLockFields()
+    {
+        const string json = """
+        {
+          "id": "77777777-7777-7777-7777-777777777777",
+          "name": "SSID",
+          "type": "STANDARD",
+          "enabled": true,
+          "metadata": { "origin": "USER_DEFINED", "configurable": true },
+          "channel2gLockedTo6": true,
+          "dtimPeriod2gLockedTo3": false
+        }
+        """;
+
+        var wifi = JsonSerializer.Deserialize<WifiBroadcast>(json, Options);
+
+        Assert.NotNull(wifi);
+        Assert.True(wifi!.Channel2gLockedTo6);
+        Assert.False(wifi.DtimPeriod2gLockedTo3);
+    }
+}


### PR DESCRIPTION
## Summary

Brings `UniFi.Net.Network` from v10.1.84 to full **v10.4.57** parity. The delta was derived by diffing the official OpenAPI specs for both versions and is **purely additive — no breaking changes** (67 → 73 endpoints, 0 removals).

### New Switching resource group (6 read-only `GET` endpoints)
Under `proxy/network/integration/v1/sites/{siteId}/switching/`:

| Method | Path |
|---|---|
| `ListLags` / `GetLag` | `.../switching/lags[/{lagId}]` |
| `ListMcLagDomains` / `GetMcLagDomain` | `.../switching/mc-lag-domains[/{id}]` |
| `ListSwitchStacks` / `GetSwitchStack` | `.../switching/switch-stacks[/{id}]` |

### Models
- `Models/Lag.cs` — `Lag`, `LagMember`, `LagSummary`, `LagType`
- `Models/McLagDomain.cs` — `McLagDomain`, `McLagPeer`, `McLagPeerRole`
- `Models/SwitchStack.cs` — `SwitchStack`, `SwitchStackMember`

The polymorphic LAG response (`LOCAL`/`MULTI_CHASSIS`/`SWITCH_STACK`) is **flattened** into a single `Lag` record with a `LagType` discriminator + nullable type-specific ids, matching the existing `ResourceMetadata`/`MetadataOrigin` convention. No custom converter needed — the existing `SnakeCaseEnumConverter` already emits the `UPPER_SNAKE` values the API uses.

### WiFi broadcast
Added the two new v10.4.57 fields — `Channel2gLockedTo6`, `DtimPeriod2gLockedTo3` — to the detail, create, and update models (optional, default `null`).

### Other
- Package version bumped `2.0.0` → `2.1.0` (backward-compatible feature addition).
- Design spec: `docs/superpowers/specs/2026-07-21-network-v10.4.57-design.md`.

## Testing
- `dotnet build` — clean across net8.0/9.0/10.0, 0 warnings.
- `dotnet test` — 17/17 passed (13 existing + 4 new `SwitchingModelTests` covering all three LAG discriminator values, MC-LAG peer roles, switch-stack members, and the new WiFi fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)