### PR TITLE
Add draft-release preparation flow for controlled stable releases

### DIFF
--- a/.github/workflows/network-release.yml
+++ b/.github/workflows/network-release.yml
@@ -1,8 +1,11 @@
 name: Network Release
 
 # Publishes UniFi.Net.Network to nuget.org via NuGet Trusted Publishing (OIDC, no long-lived API
-# key stored in this repo). Triggered manually so releases to the public feed are always
-# deliberate. The version comes from the project file; a prerelease run appends -beta.<run_number>.
+# key stored in this repo). Stable releases run when a GitHub release is published (the Prepare
+# Network Release workflow stages the draft; publishing it mints the tag). Manual dispatch remains
+# for betas (and for a stable re-run from the tag ref if ever needed). The version comes from the
+# project file; a prerelease run appends -beta.<run_number>. For a release event the isprerelease
+# input is absent, which evaluates as a stable release throughout.
 on:
   workflow_dispatch:
     inputs:
@@ -10,6 +13,8 @@ on:
         description: "Pre-release"
         default: true
         type: boolean
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -17,8 +22,12 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    # Stable runs are expected to be dispatched FROM the version tag ref, not from main.
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+    # Stable runs are expected to run FROM the version tag ref, not from main. A GitHub release
+    # marked as a pre-release does not publish: betas go through manual dispatch, where the
+    # -beta.<run_number> suffix keeps the version distinct.
+    if: >-
+      ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))
+       || (github.event_name == 'release' && !github.event.release.prerelease && startsWith(github.ref, 'refs/tags/v')) }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/prepare-network-release.yml
+++ b/.github/workflows/prepare-network-release.yml
@@ -1,0 +1,69 @@
+name: Prepare Network Release
+
+# Creates a DRAFT GitHub release for the version in the Network project file after verifying the
+# commit is release-ready. A draft creates no tag; publishing it is a manual, human action that
+# mints the version tag under the publisher's own account (so tag rulesets apply unchanged) and
+# triggers the Network Release workflow. Publishing to nuget.org still waits for the protected
+# nuget.org environment approval inside that workflow.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write   # create the draft release
+      checks: read      # verify the build check on HEAD
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+    - name: Get version info
+      id: get-version-number
+      uses: AndrewMcLachlan/Actions/get-version-number-from-project@d3e53c04be8287ab0c19ec485b0741a7d166ea31 # v4
+      with:
+        project: src/UniFi.Net.Network/UniFi.Net.Network.csproj
+
+    - name: Verify the release is new
+      id: tag
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        TAG="v${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}"
+        if git ls-remote --exit-code --tags origin "refs/tags/$TAG" > /dev/null; then
+          echo "::error::Tag $TAG already exists. Bump the Version in UniFi.Net.Network.csproj before preparing a release."
+          exit 1
+        fi
+        if gh release list --repo "${{ github.repository }}" --json tagName,isDraft --jq ".[] | select(.isDraft and .tagName == \"$TAG\")" | grep -q .; then
+          echo "::error::A draft release for $TAG already exists. Publish or delete it before preparing another."
+          exit 1
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Verify CI is green for this commit
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" --jq '[.check_runs[] | select(.name == "build")] | first | .conclusion // empty')
+        if [ "$CONCLUSION" != "success" ]; then
+          echo "::error::The 'build' check has not succeeded for ${{ github.sha }} (found: '${CONCLUSION:-none}'). Release from a commit with green CI."
+          exit 1
+        fi
+
+    - name: Create draft release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "${{ steps.tag.outputs.tag }}" \
+          --repo "${{ github.repository }}" \
+          --draft \
+          --target "${{ github.sha }}" \
+          --title "${{ steps.tag.outputs.tag }}" \
+          --generate-notes
+        {
+          echo "### Draft release ${{ steps.tag.outputs.tag }} created for ${{ github.sha }}"
+          echo "Review the draft, then publish it to mint the tag and start the Network Release workflow."
+        } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Replaces "push a tag by hand" as the stable-release entry point with a controlled, verified flow, mirroring the same change in Postie:

- **New `Prepare Network Release` workflow** (manual dispatch from `main`): verifies the version in `UniFi.Net.Network.csproj` is untagged, no draft already exists, and the `build` check succeeded for HEAD — then creates a **draft** GitHub release with generated notes targeting that exact SHA. A draft creates no tag.
- **`Network Release` now also triggers on `release: published`**: publishing the draft (a manual, human click) mints the `vX.Y.Z` tag under the publisher's own account — tag rulesets apply unchanged — and starts the release run from the tag ref as a stable release. The existing tag-anchor guard still applies, and publishing to nuget.org still waits for the protected `nuget.org` environment approval.
- GitHub releases marked *pre-release* never trigger a publish; betas remain manual `workflow_dispatch` only.

## Security posture

No change in authority: tag minting stays under your account (no ruleset bypass for Actions, no stored PAT/App key), and both human gates (publish-the-draft, approve-the-environment) remain. The prepare workflow's token has `contents: write` + `checks: read` only, and the trusted-publishing binding to `network-release.yml` + environment `nuget.org` is untouched.

## Note for later

When a second package (e.g. SiteManager) ships from this repo, the plain `v*` tag scheme will need per-package namespacing and the `release: published` trigger will need to filter by tag prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)