### PR TITLE
Site Manager v1.0.0 release readiness

### DIFF
--- a/.github/workflows/prepare-sitemanager-release.yml
+++ b/.github/workflows/prepare-sitemanager-release.yml
@@ -1,0 +1,71 @@
+name: Prepare Site Manager Release
+
+# Creates a DRAFT GitHub release for the version in the Site Manager project file after verifying
+# the commit is release-ready. A draft creates no tag; publishing it is a manual, human action that
+# mints the version tag under the publisher's own account (so tag rulesets apply unchanged) and
+# triggers the Site Manager Release workflow. Publishing to nuget.org still waits for the protected
+# nuget.org environment approval inside that workflow.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write   # create the draft release
+      checks: read      # verify the build check on HEAD
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+    - name: Get version info
+      id: get-version-number
+      uses: AndrewMcLachlan/Actions/get-version-number-from-project@d3e53c04be8287ab0c19ec485b0741a7d166ea31 # v4
+      with:
+        project: src/UniFi.Net.SiteManager/UniFi.Net.SiteManager.csproj
+
+    - name: Verify the release is new
+      id: tag
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        TAG="sitemanager-v${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}"
+        if git ls-remote --exit-code --tags origin "refs/tags/$TAG" > /dev/null; then
+          echo "::error::Tag $TAG already exists. Bump the Version in UniFi.Net.SiteManager.csproj before preparing a release."
+          exit 1
+        fi
+        if gh release list --repo "${{ github.repository }}" --json tagName,isDraft --jq ".[] | select(.isDraft and .tagName == \"$TAG\")" | grep -q .; then
+          echo "::error::A draft release for $TAG already exists. Publish or delete it before preparing another."
+          exit 1
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    # The Site Manager CI job is path-filtered, so it only exists on commits that touched Site
+    # Manager code - release from one of those.
+    - name: Verify CI is green for this commit
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        CONCLUSION=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" --jq '[.check_runs[] | select(.name == "Site Manager build")] | first | .conclusion // empty')
+        if [ "$CONCLUSION" != "success" ]; then
+          echo "::error::The 'Site Manager build' check has not succeeded for ${{ github.sha }} (found: '${CONCLUSION:-none}'). Release from a commit with green Site Manager CI."
+          exit 1
+        fi
+
+    - name: Create draft release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release create "${{ steps.tag.outputs.tag }}" \
+          --repo "${{ github.repository }}" \
+          --draft \
+          --target "${{ github.sha }}" \
+          --title "${{ steps.tag.outputs.tag }}" \
+          --generate-notes
+        {
+          echo "### Draft release ${{ steps.tag.outputs.tag }} created for ${{ github.sha }}"
+          echo "Review the draft, then publish it to mint the tag and start the Site Manager Release workflow."
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sitemanager-ci.yml
+++ b/.github/workflows/sitemanager-ci.yml
@@ -27,6 +27,9 @@ env:
 
 jobs:
   build:
+    # Distinct display name: the Network CI job is also called "build", and the prepare-release
+    # workflows verify CI by check-run name - the two must not be confusable on a shared commit.
+    name: Site Manager build
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/sitemanager-ci.yml
+++ b/.github/workflows/sitemanager-ci.yml
@@ -1,0 +1,101 @@
+name: Site Manager CI
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "src/UniFi.Net.SiteManager/**"
+      - "src/UniFi.Net.Core/**"
+      - "tests/UniFi.Net.SiteManager.Tests/**"
+      - ".github/workflows/sitemanager-ci.yml"
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "src/UniFi.Net.SiteManager/**"
+      - "src/UniFi.Net.Core/**"
+      - "tests/UniFi.Net.SiteManager.Tests/**"
+      - ".github/workflows/sitemanager-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  NUGET_SOURCE: https://nuget.pkg.github.com/AndrewMcLachlan/index.json
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+    - name: Setup .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+      with:
+        dotnet-version: |
+          8.x
+          9.x
+          10.x
+
+    - name: Get version info
+      id: get-version-number
+      uses: AndrewMcLachlan/Actions/get-version-number-from-project@d3e53c04be8287ab0c19ec485b0741a7d166ea31 # v4
+      with:
+        project: src/UniFi.Net.SiteManager/UniFi.Net.SiteManager.csproj
+
+    - name: Set package version
+      id: set-version
+      run: echo "package-version=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}-ci.${{ github.run_number }}" >> $GITHUB_OUTPUT
+
+    - name: Restore
+      run: |
+        dotnet restore src/UniFi.Net.SiteManager
+        dotnet restore tests/UniFi.Net.SiteManager.Tests
+
+    # Build once with the release version properties; test and pack reuse these binaries so the
+    # packed assemblies carry the intended versions.
+    - name: Build
+      run: |
+        dotnet build src/UniFi.Net.SiteManager --no-restore --configuration Release --p:Version=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}.0 --p:FileVersion=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}.${{ github.run_number }} --p:InformationalVersion=${{ steps.set-version.outputs.package-version }}
+        dotnet build tests/UniFi.Net.SiteManager.Tests --no-restore --configuration Release
+
+    - name: Test
+      run: dotnet test tests/UniFi.Net.SiteManager.Tests --no-build --configuration Release
+
+    - name: Package
+      run: dotnet pack src/UniFi.Net.SiteManager --no-restore --no-build -o ${{ github.workspace }}/publish --configuration Release --p:Version=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}.0 --p:PackageVersion=${{ steps.set-version.outputs.package-version }}
+
+    - name: Upload packages
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: packages
+        path: |
+          ${{ github.workspace }}/publish/*.nupkg
+          ${{ github.workspace }}/publish/*.snupkg
+        retention-days: 30
+
+  publish-github-packages:
+    needs: build
+    if: (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+    - name: Download packages
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: packages
+        path: ${{ github.workspace }}/publish
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+      with:
+        dotnet-version: 10.x
+
+    # No rebuild here: this publishes exactly the artifacts validated by the build job above.
+    - name: Publish packages
+      run: dotnet nuget push ${{ github.workspace }}/publish/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source ${{ env.NUGET_SOURCE }} --skip-duplicate

--- a/.github/workflows/sitemanager-release.yml
+++ b/.github/workflows/sitemanager-release.yml
@@ -1,8 +1,11 @@
 name: Site Manager Release
 
 # Publishes UniFi.Net.SiteManager to nuget.org via NuGet Trusted Publishing (OIDC, no long-lived
-# API key stored in this repo). Triggered manually so releases to the public feed are always
-# deliberate. The version comes from the project file; a prerelease run appends -beta.<run_number>.
+# API key stored in this repo). Stable releases run when a GitHub release is published (the Prepare
+# Site Manager Release workflow stages the draft; publishing it mints the tag). Manual dispatch
+# remains for betas (and for a stable re-run from the tag ref if ever needed). The version comes
+# from the project file; a prerelease run appends -beta.<run_number>. For a release event the
+# isprerelease input is absent, which evaluates as a stable release throughout.
 on:
   workflow_dispatch:
     inputs:
@@ -10,6 +13,8 @@ on:
         description: "Pre-release"
         default: true
         type: boolean
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -17,8 +22,12 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    # Stable runs are expected to be dispatched FROM the version tag ref, not from main.
-    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/sitemanager-v') }}
+    # Stable runs are expected to run FROM the version tag ref, not from main. A GitHub release
+    # marked as a pre-release does not publish: betas go through manual dispatch, where the
+    # -beta.<run_number> suffix keeps the version distinct.
+    if: >-
+      ${{ (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/sitemanager-v')))
+       || (github.event_name == 'release' && !github.event.release.prerelease && startsWith(github.ref, 'refs/tags/sitemanager-v')) }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sitemanager-release.yml
+++ b/.github/workflows/sitemanager-release.yml
@@ -1,0 +1,128 @@
+name: Site Manager Release
+
+# Publishes UniFi.Net.SiteManager to nuget.org via NuGet Trusted Publishing (OIDC, no long-lived
+# API key stored in this repo). Triggered manually so releases to the public feed are always
+# deliberate. The version comes from the project file; a prerelease run appends -beta.<run_number>.
+on:
+  workflow_dispatch:
+    inputs:
+      isprerelease:
+        description: "Pre-release"
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    # Stable runs are expected to be dispatched FROM the version tag ref, not from main.
+    if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/sitemanager-v') }}
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+      with:
+        dotnet-version: |
+          8.x
+          9.x
+          10.x
+
+    - name: Get version info
+      id: get-version-number
+      uses: AndrewMcLachlan/Actions/get-version-number-from-project@d3e53c04be8287ab0c19ec485b0741a7d166ea31 # v4
+      with:
+        project: src/UniFi.Net.SiteManager/UniFi.Net.SiteManager.csproj
+
+    - name: Set package version
+      id: set-version
+      run: |
+        if [ "${{ inputs.isprerelease }}" = "true" ]; then
+          echo "package-version=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}-beta.${{ github.run_number }}" >> $GITHUB_OUTPUT
+        else
+          echo "package-version=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}" >> $GITHUB_OUTPUT
+        fi
+
+    # Anchors a stable publish to a specific, reviewed, protected tag instead of whatever main
+    # happens to be at dispatch time.
+    - name: Verify release tag (stable only)
+      if: ${{ !inputs.isprerelease }}
+      run: |
+        TAG="sitemanager-v${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}"
+        # A commit can carry several tags; check membership rather than a single reported tag.
+        if ! git tag --points-at HEAD | grep -Fxq "$TAG"; then
+          ACTUAL=$(git tag --points-at HEAD | paste -sd, - )
+          echo "::error::Stable releases must run from the exact version tag $TAG (HEAD is '$ACTUAL')."
+          exit 1
+        fi
+
+    - name: Restore
+      run: |
+        dotnet restore src/UniFi.Net.SiteManager
+        dotnet restore tests/UniFi.Net.SiteManager.Tests
+
+    # Build once with the release version properties; test and pack reuse these binaries so the
+    # packed assemblies carry the intended versions.
+    - name: Build
+      run: |
+        dotnet build src/UniFi.Net.SiteManager --no-restore --configuration Release --p:Version=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}.0 --p:FileVersion=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}.${{ github.run_number }} --p:InformationalVersion=${{ steps.set-version.outputs.package-version }}
+        dotnet build tests/UniFi.Net.SiteManager.Tests --no-restore --configuration Release
+
+    - name: Test
+      run: dotnet test tests/UniFi.Net.SiteManager.Tests --no-build --configuration Release
+
+    - name: Package
+      run: dotnet pack src/UniFi.Net.SiteManager --no-restore --no-build -o ${{ github.workspace }}/publish --configuration Release --p:Version=${{ steps.get-version-number.outputs.major }}.${{ steps.get-version-number.outputs.minor }}.${{ steps.get-version-number.outputs.patch }}.0 --p:PackageVersion=${{ steps.set-version.outputs.package-version }}
+
+    - name: Upload packages
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: packages
+        path: |
+          ${{ github.workspace }}/publish/*.nupkg
+          ${{ github.workspace }}/publish/*.snupkg
+        retention-days: 90
+
+  publish:
+    needs: validate
+    runs-on: ubuntu-latest
+    # Protected environment - publishing waits for manual approval before the OIDC exchange.
+    environment: nuget.org
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - name: Download packages
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: packages
+        path: ${{ github.workspace }}/publish
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+      with:
+        dotnet-version: 10.x
+
+    # NuGet Trusted Publishing: exchanges this job's GitHub OIDC token for a short-lived (1 hour)
+    # nuget.org API key. Requires a Trusted Publishing policy configured on nuget.org for this
+    # repo/workflow (scoped to the "nuget.org" environment) and the NUGET_USER repository variable
+    # set to the nuget.org profile name. See https://learn.microsoft.com/nuget/nuget-org/trusted-publishing
+    - name: NuGet login (OIDC)
+      id: login
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+      with:
+        user: ${{ vars.NUGET_USER }}
+
+    # No rebuild here: this publishes exactly the artifacts validated by the validate job above.
+    # The matching .snupkg symbol packages are pushed automatically alongside each .nupkg because
+    # both sit in the same downloaded folder - do not separate them into subfolders.
+    # --skip-duplicate: retries re-publish the identical validated artifacts from this run's
+    # upload, so skipping already-pushed IDs is safe and enables partial-failure retry.
+    - name: Publish to NuGet.org
+      run: dotnet nuget push ${{ github.workspace }}/publish/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/UniFi.Net.slnx
+++ b/UniFi.Net.slnx
@@ -3,6 +3,8 @@
     <File Path=".github/CODEOWNERS" />
     <File Path=".github/workflows/network-ci.yml" />
     <File Path=".github/workflows/network-release.yml" />
+    <File Path=".github/workflows/sitemanager-ci.yml" />
+    <File Path=".github/workflows/sitemanager-release.yml" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
@@ -12,6 +14,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/UniFi.Net.Network.Tests/UniFi.Net.Network.Tests.csproj" Id="f7a46982-6089-48fb-981d-d3d82b962771" />
     <Project Path="tests/UniFi.Net.Network.IntegrationTests/UniFi.Net.Network.IntegrationTests.csproj" />
+    <Project Path="tests/UniFi.Net.SiteManager.Tests/UniFi.Net.SiteManager.Tests.csproj" />
     <Project Path="tests/UniFi.Net.TestHarness/UniFi.Net.TestHarness.csproj" />
   </Folder>
   <Project Path="src/UniFi.Net.Access/UniFi.Net.Access.csproj" />

--- a/UniFi.Net.slnx
+++ b/UniFi.Net.slnx
@@ -3,6 +3,8 @@
     <File Path=".github/CODEOWNERS" />
     <File Path=".github/workflows/network-ci.yml" />
     <File Path=".github/workflows/network-release.yml" />
+    <File Path=".github/workflows/prepare-network-release.yml" />
+    <File Path=".github/workflows/prepare-sitemanager-release.yml" />
     <File Path=".github/workflows/sitemanager-ci.yml" />
     <File Path=".github/workflows/sitemanager-release.yml" />
   </Folder>

--- a/src/UniFi.Net.Core/Serialization/CamelCaseEnumConverter.cs
+++ b/src/UniFi.Net.Core/Serialization/CamelCaseEnumConverter.cs
@@ -1,0 +1,10 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace UniFi.Net.Serialization;
+internal class CamelCaseEnumConverter : JsonStringEnumConverter
+{
+    public CamelCaseEnumConverter() : base(JsonNamingPolicy.CamelCase, allowIntegerValues: false)
+    {
+    }
+}

--- a/src/UniFi.Net.Core/UniFi.Net.Core.projitems
+++ b/src/UniFi.Net.Core/UniFi.Net.Core.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>UniFi.Net.Core</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\CamelCaseEnumConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\SnakeCaseEnumConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\SnakeCaseNamingPolicy.cs" />
   </ItemGroup>

--- a/src/UniFi.Net.SiteManager/ISiteManagerClient.cs
+++ b/src/UniFi.Net.SiteManager/ISiteManagerClient.cs
@@ -1,43 +1,97 @@
-﻿using UniFi.Net.SiteManager.Models;
+using UniFi.Net.SiteManager.Models;
 
 namespace UniFi.Net.SiteManager;
 
 /// <summary>
-///
+/// Client for the UniFi Site Manager API.
 /// </summary>
 public interface ISiteManagerClient
 {
     /// <summary>
     /// Gets a paged list of hosts.
     /// </summary>
+    /// <param name="pageSize">The number of items to return per page.</param>
+    /// <param name="nextToken">A token for retrieving the next page of results.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A paged response of hosts.</returns>
     Task<PagedResponse<Host>> ListHostsAsync(int? pageSize = null, string? nextToken = null, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets a host.
+    /// Gets a host by ID.
     /// </summary>
     /// <param name="id">The host ID.</param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>The host.</returns>
     Task<DataResponse<Host>> GetHostAsync(string id, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a paged list of sites.
     /// </summary>
+    /// <param name="pageSize">The number of items to return per page.</param>
+    /// <param name="nextToken">A token for retrieving the next page of results.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A paged response of sites.</returns>
     Task<PagedResponse<Site>> ListSitesAsync(int? pageSize = null, string? nextToken = null, CancellationToken cancellationToken = default);
 
-
+    /// <summary>
+    /// Gets a paged list of devices, optionally filtered by host IDs.
+    /// </summary>
+    /// <param name="hostIds">Optional list of host IDs to filter the results.</param>
+    /// <param name="time">Optional timestamp to filter devices by last processed time.</param>
+    /// <param name="pageSize">The number of items to return per page.</param>
+    /// <param name="nextToken">A token for retrieving the next page of results.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A paged response of hosts with their devices.</returns>
     Task<PagedResponse<HostWithDevices>> ListDevicesAsync(IEnumerable<string>? hostIds = null, DateTimeOffset? time = null, int? pageSize = null, string? nextToken = null, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets ISP metrics for the specified interval, optionally filtered by time range.
+    /// </summary>
+    /// <param name="type">The metric interval (5-minute or 1-hour).</param>
+    /// <param name="beginTimestamp">The earliest timestamp to retrieve data from.</param>
+    /// <param name="endTimestamp">The latest timestamp to retrieve data up to.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>ISP metrics data.</returns>
     Task<DataResponse<IReadOnlyList<IspMetric>>> GetIspMetricsAsync(MetricInterval type, DateTimeOffset? beginTimestamp = null, DateTimeOffset? endTimestamp = null, CancellationToken cancellationToken = default);
 
-    Task<DataResponse<IReadOnlyList<IspMetric>>> GetIspMetricsAsync(MetricInterval type, string? duration = null, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets ISP metrics for the specified interval, filtered by duration.
+    /// </summary>
+    /// <param name="type">The metric interval (5-minute or 1-hour).</param>
+    /// <param name="duration">The time range of metrics to retrieve, ending at the current time. Valid values: 24h (5-minute interval), 7d or 30d (1-hour interval).</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>ISP metrics data.</returns>
+    Task<DataResponse<IReadOnlyList<IspMetric>>> GetIspMetricsAsync(MetricInterval type, string duration, CancellationToken cancellationToken = default);
 
-    Task<DataResponse<IReadOnlyList<IspMetric>>> QueryIspMetricsAsync(MetricInterval type, IEnumerable<IspMetricsQuery> sites, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Queries ISP metrics for specific sites.
+    /// </summary>
+    /// <param name="type">The metric interval (5-minute or 1-hour).</param>
+    /// <param name="sites">The site queries specifying host/site IDs and time ranges.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>ISP metrics data for the queried sites.</returns>
+    Task<DataResponse<IspMetricsQueryResult>> QueryIspMetricsAsync(MetricInterval type, IEnumerable<IspMetricsQuery> sites, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets a list of SD-WAN configurations.
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A list of SD-WAN configurations.</returns>
     Task<DataResponse<IReadOnlyList<BasicSDWanConfig>>> ListSDWanConfigsAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets an SD-WAN configuration by ID.
+    /// </summary>
+    /// <param name="id">The SD-WAN configuration ID.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>The SD-WAN configuration.</returns>
     Task<DataResponse<SDWanConfig>> GetSDWanConfigAsync(Guid id, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Gets the status of an SD-WAN configuration.
+    /// </summary>
+    /// <param name="id">The SD-WAN configuration ID.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>The SD-WAN configuration status.</returns>
     Task<DataResponse<SDWanConfigStatus>> GetSDWanConfigStatusAsync(Guid id, CancellationToken cancellationToken = default);
-
 }

--- a/src/UniFi.Net.SiteManager/Models/Device.cs
+++ b/src/UniFi.Net.SiteManager/Models/Device.cs
@@ -36,10 +36,10 @@ public record Device(
     string? UpdateAvailable,
     bool IsConsole,
     bool IsManaged,
-    DateTimeOffset StartupTime,
+    DateTimeOffset? StartupTime,
     DateTimeOffset? AdoptionTime,
     string? Note,
-    Uidb Uidb
+    Uidb? Uidb
 );
 
 /// <summary>
@@ -49,7 +49,7 @@ public record Device(
 /// <param name="Id">Identifier for the UI metadata.</param>
 /// <param name="Images">Images associated with the device.</param>
 public record Uidb(
-    Guid Guid,
-    string Id,
-    IDictionary<string, string> Images
+    Guid? Guid,
+    string? Id,
+    IReadOnlyDictionary<string, string>? Images
 );

--- a/src/UniFi.Net.SiteManager/Models/Host.cs
+++ b/src/UniFi.Net.SiteManager/Models/Host.cs
@@ -1,20 +1,6 @@
 namespace UniFi.Net.SiteManager.Models;
 
 /// <summary>
-/// Represents the response containing a list of hosts.
-/// </summary>
-/// <param name="Data">List of host devices.</param>
-/// <param name="HttpStatusCode">HTTP status code of the response.</param>
-/// <param name="TraceId">Trace identifier for the request.</param>
-/// <param name="NextToken">Token for fetching the next set of results, if available.</param>
-public record ListHostsResponse(
-    IReadOnlyList<Host> Data,
-    int HttpStatusCode,
-    string TraceId,
-    string? NextToken
-);
-
-/// <summary>
 /// Represents a host device.
 /// </summary>
 /// <param name="Id">Unique identifier of the host device.</param>
@@ -27,7 +13,7 @@ public record ListHostsResponse(
 /// <param name="LastConnectionStateChange">Time in RFC3339 format when the connection state last changed.</param>
 /// <param name="LatestBackupTime">Time in RFC3339 format of the latest device backup.</param>
 /// <param name="UserData">User-specific data associated with the device including permissions and role information.</param>
-/// <param name="ReportedState">Device’s reported state information.</param>
+/// <param name="ReportedState">The device's reported state information.</param>
 public record Host(
     string Id,
     string HardwareId,
@@ -43,19 +29,19 @@ public record Host(
 );
 
 /// <summary>
-/// Use information.
+/// User-specific data associated with a host.
 /// </summary>
 /// <param name="Apps">The user's apps.</param>
-/// <param name="ConsoleGroupMembers"></param>
-/// <param name="Controllers"></param>
-/// <param name="Email"></param>
-/// <param name="Features"></param>
-/// <param name="FullName"></param>
-/// <param name="LocalId"></param>
-/// <param name="Permissions"></param>
-/// <param name="Role"></param>
-/// <param name="RoleId"></param>
-/// <param name="Status"></param>
+/// <param name="ConsoleGroupMembers">The members of the console group.</param>
+/// <param name="Controllers">The controllers available on the host.</param>
+/// <param name="Email">The user's email address.</param>
+/// <param name="Features">The features available to the user.</param>
+/// <param name="FullName">The user's full name.</param>
+/// <param name="LocalId">The user's local identifier.</param>
+/// <param name="Permissions">The user's permissions, keyed by permission name.</param>
+/// <param name="Role">The user's role.</param>
+/// <param name="RoleId">The identifier of the user's role.</param>
+/// <param name="Status">The user's status.</param>
 public record UserData(
     IReadOnlyList<string> Apps,
     IReadOnlyList<ConsoleGroupMember> ConsoleGroupMembers,
@@ -73,10 +59,10 @@ public record UserData(
 /// <summary>
 /// Represents a console group member.
 /// </summary>
-/// <param name="Mac"></param>
-/// <param name="Role"></param>
-/// <param name="RoleAttributes"></param>
-/// <param name="SysId"></param>
+/// <param name="Mac">The MAC address of the member.</param>
+/// <param name="Role">The role of the member within the group.</param>
+/// <param name="RoleAttributes">The attributes of the member's role.</param>
+/// <param name="SysId">The system identifier of the member.</param>
 public record ConsoleGroupMember(
     string Mac,
     string Role,
@@ -84,6 +70,13 @@ public record ConsoleGroupMember(
     int SysId
 );
 
+/// <summary>
+/// Attributes of a console group member's role.
+/// </summary>
+/// <param name="Applications">The applications available to the role, keyed by application name.</param>
+/// <param name="CandidateRoles">The candidate roles for the member.</param>
+/// <param name="ConnectedState">The connected state of the member.</param>
+/// <param name="ConnectedStateLastChanged">The time the connected state last changed.</param>
 public record RoleAttributes(
     IReadOnlyDictionary<string, Application> Applications,
     IReadOnlyList<string> CandidateRoles,
@@ -91,12 +84,27 @@ public record RoleAttributes(
     string ConnectedStateLastChanged
 );
 
+/// <summary>
+/// Application availability for a role.
+/// </summary>
+/// <param name="Owned">Indicates if the application is owned.</param>
+/// <param name="Required">Indicates if the application is required.</param>
+/// <param name="Supported">Indicates if the application is supported.</param>
 public record Application(
     bool Owned,
     bool Required,
     bool Supported
 );
 
+/// <summary>
+/// Features available to a user.
+/// </summary>
+/// <param name="DeviceGroups">Indicates if device groups are available.</param>
+/// <param name="Floorplan">Floorplan feature availability.</param>
+/// <param name="ManageApplications">Indicates if the user can manage applications.</param>
+/// <param name="Notifications">Indicates if notifications are available.</param>
+/// <param name="Pion">Indicates if Pion is available.</param>
+/// <param name="WebRtc">WebRTC feature availability.</param>
 public record Features(
     bool DeviceGroups,
     Floorplan Floorplan,
@@ -106,14 +114,24 @@ public record Features(
     WebRtc WebRtc
 );
 
+/// <summary>
+/// Floorplan feature availability.
+/// </summary>
+/// <param name="CanEdit">Indicates if the user can edit floorplans.</param>
+/// <param name="CanView">Indicates if the user can view floorplans.</param>
 public record Floorplan(
     bool CanEdit,
     bool CanView
 );
 
+/// <summary>
+/// WebRTC feature availability.
+/// </summary>
+/// <param name="IceRestart">Indicates if ICE restart is supported.</param>
+/// <param name="MediaStreams">Indicates if media streams are supported.</param>
+/// <param name="TwoWayAudio">Indicates if two-way audio is supported.</param>
 public record WebRtc(
     bool IceRestart,
     bool MediaStreams,
     bool TwoWayAudio
 );
-

--- a/src/UniFi.Net.SiteManager/Models/HostWithDevices.cs
+++ b/src/UniFi.Net.SiteManager/Models/HostWithDevices.cs
@@ -5,7 +5,7 @@
 /// </summary>
 /// <param name="HostId">Unique identifier of the host device.</param>
 /// <param name="HostName">Name of the host device.</param>
-/// <param name="Devices">Array of devices managed by this host.+</param>
+/// <param name="Devices">Array of devices managed by this host.</param>
 /// <param name="UpdatedAt">Last update time.</param>
 public record HostWithDevices(
     string HostId,

--- a/src/UniFi.Net.SiteManager/Models/IspMetric.cs
+++ b/src/UniFi.Net.SiteManager/Models/IspMetric.cs
@@ -1,5 +1,14 @@
-﻿namespace UniFi.Net.SiteManager.Models;
+using System.Text.Json.Serialization;
 
+namespace UniFi.Net.SiteManager.Models;
+
+/// <summary>
+/// Represents ISP metrics for a site.
+/// </summary>
+/// <param name="MetricType">The metric interval type (5m or 1h).</param>
+/// <param name="Periods">The metric data periods.</param>
+/// <param name="HostId">Unique identifier of the host device.</param>
+/// <param name="SiteId">Unique identifier of the site.</param>
 public record IspMetric(
     string MetricType,
     IReadOnlyList<IspMetricPeriod> Periods,
@@ -7,24 +16,58 @@ public record IspMetric(
     string SiteId
 );
 
+/// <summary>
+/// Represents the result of an ISP metrics query.
+/// </summary>
+/// <param name="Metrics">The ISP metrics for the queried sites.</param>
+/// <param name="Message">An informational message about the query, if any.</param>
+/// <param name="Status">The status of the query, if any.</param>
+public record IspMetricsQueryResult(
+    IReadOnlyList<IspMetric> Metrics,
+    string? Message,
+    string? Status
+);
+
+/// <summary>
+/// Represents a single period of ISP metric data.
+/// </summary>
+/// <param name="Data">The metric data for the period.</param>
+/// <param name="MetricTime">The time the metrics were recorded.</param>
+/// <param name="Version">The metrics data version.</param>
 public record IspMetricPeriod(
     IspMetricData Data,
     DateTimeOffset MetricTime,
     string Version
 );
 
+/// <summary>
+/// Represents the metric data for a period.
+/// </summary>
+/// <param name="Wan">The WAN metrics.</param>
 public record IspMetricData(
     IspMetricWan Wan
 );
 
+/// <summary>
+/// Represents WAN metrics for a period.
+/// </summary>
+/// <param name="AvgLatency">Average latency in milliseconds.</param>
+/// <param name="DownloadKbps">Download speed in kilobits per second.</param>
+/// <param name="Downtime">Downtime in milliseconds.</param>
+/// <param name="IspAsn">The ISP's autonomous system number.</param>
+/// <param name="IspName">The ISP name.</param>
+/// <param name="MaxLatency">Maximum latency in milliseconds.</param>
+/// <param name="PacketLoss">Packet loss percentage.</param>
+/// <param name="UploadKbps">Upload speed in kilobits per second.</param>
+/// <param name="Uptime">Uptime in milliseconds.</param>
 public record IspMetricWan(
     int AvgLatency,
-    int DownloadKbps,
+    [property: JsonPropertyName("download_kbps")] int DownloadKbps,
     int Downtime,
     string IspAsn,
     string IspName,
     int MaxLatency,
     int PacketLoss,
-    int UploadKbps,
+    [property: JsonPropertyName("upload_kbps")] int UploadKbps,
     int Uptime
 );

--- a/src/UniFi.Net.SiteManager/Models/IspMetricsQuery.cs
+++ b/src/UniFi.Net.SiteManager/Models/IspMetricsQuery.cs
@@ -25,3 +25,11 @@ public record IspMetricsQuery
     /// </summary>
     public required string SiteId { get; init; }
 }
+
+/// <summary>
+/// The request body for an ISP metrics query.
+/// </summary>
+/// <param name="Sites">The site queries specifying host/site IDs and time ranges.</param>
+internal record IspMetricsQueryRequest(
+    IEnumerable<IspMetricsQuery> Sites
+);

--- a/src/UniFi.Net.SiteManager/Models/SDWanConfig.cs
+++ b/src/UniFi.Net.SiteManager/Models/SDWanConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace UniFi.Net.SiteManager.Models;
+﻿using System.Text.Json.Serialization;
+using UniFi.Net.Serialization;
+
+namespace UniFi.Net.SiteManager.Models;
 
 /// <summary>
 /// Basic configuration for SD-WAN.
@@ -95,6 +98,7 @@ public record SDWanSpoke(
 /// <summary>
 /// Variant of SD-WAN configuration. Values: distributed, failover, single.
 /// </summary>
+[JsonConverter(typeof(CamelCaseEnumConverter))]
 public enum SDWanVariant
 {
     /// <summary>
@@ -116,7 +120,8 @@ public enum SDWanVariant
 /// </summary>
 /// <remarks>This enumeration defines the available modes for configuring spoke-to-hub tunnels,
 /// each offering different trade-offs between resiliency, redundancy, and scalability.</remarks>
-public enum  SpokeToHubTunnelsMode
+[JsonConverter(typeof(CamelCaseEnumConverter))]
+public enum SpokeToHubTunnelsMode
 {
     /// <summary>
     /// Maximum resiliency.
@@ -133,8 +138,9 @@ public enum  SpokeToHubTunnelsMode
 }
 
 /// <summary>
-/// Spoke-to-hub routing. Values: custom, scalable.
+/// Spoke-to-hub routing. Values: custom, geo.
 /// </summary>
+[JsonConverter(typeof(CamelCaseEnumConverter))]
 public enum SpokeToHubRouting
 {
     /// <summary>

--- a/src/UniFi.Net.SiteManager/Models/SDWanConfigStatus.cs
+++ b/src/UniFi.Net.SiteManager/Models/SDWanConfigStatus.cs
@@ -86,7 +86,7 @@ public record SDWanConfigStatusSpoke(
     IReadOnlyList<SDWanConfigStatusNetwork> Networks,
     IReadOnlyList<SDWanConfigStatusRoute> Routes,
     IReadOnlyList<SDWanConfigStatusConnection> Connections,
-    string ApplyStatus
+    ApplyStatus ApplyStatus
 );
 
 /// <summary>
@@ -157,6 +157,7 @@ public record SDWanConfigStatusTunnel(
 /// <remarks>This enumeration is used to indicate the current state of a configuration operation, such as
 /// creation, update, or removal. It provides detailed statuses to help track the progress or identify failures during
 /// these operations.</remarks>
+[JsonConverter(typeof(CamelCaseEnumConverter))]
 public enum ApplyStatus
 {
     /// <summary>
@@ -194,6 +195,7 @@ public enum ApplyStatus
 /// </summary>
 /// <remarks>This enumeration is used to indicate the current state of a tunnel connection. It can be used to
 /// determine whether a tunnel is actively connected, disconnected, or in the process of connecting.</remarks>
+[JsonConverter(typeof(CamelCaseEnumConverter))]
 public enum TunnelStatus
 {
     /// <summary>

--- a/src/UniFi.Net.SiteManager/Models/Site.cs
+++ b/src/UniFi.Net.SiteManager/Models/Site.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace UniFi.Net.SiteManager.Models;
 
 /// <summary>
-///
+/// Represents a site managed by a host.
 /// </summary>
 /// <param name="SiteId">Unique identifier of the site.</param>
 /// <param name="HostId">Unique identifier of the host device managing this site.</param>
@@ -34,16 +34,30 @@ public record SiteMeta(
     [property:JsonPropertyName("timezone")]string TimeZone
 );
 
-
+/// <summary>
+/// Site statistics.
+/// </summary>
+/// <param name="Counts">Device and client counts, keyed by count name.</param>
+/// <param name="Gateway">Gateway information.</param>
+/// <param name="InternetIssues">Internet issues reported for the site.</param>
+/// <param name="IspInfo">ISP information.</param>
+/// <param name="Percentages">Percentage metrics, keyed by metric name.</param>
 public record SiteStatistics(
     IReadOnlyDictionary<string, int> Counts,
     SiteGateway Gateway,
-    IReadOnlyList<object> InternetIssues, // Use a more specific type if known
+    IReadOnlyList<object> InternetIssues,
     SiteIspInfo IspInfo,
     IReadOnlyDictionary<string, int> Percentages
 );
 
-
+/// <summary>
+/// Gateway information for a site.
+/// </summary>
+/// <param name="HardwareId">Hardware identifier of the gateway.</param>
+/// <param name="InspectionState">The traffic inspection state.</param>
+/// <param name="IpsMode">The intrusion prevention system mode.</param>
+/// <param name="IpsSignature">The intrusion prevention system signature information.</param>
+/// <param name="Shortname">Short identifier of the gateway model.</param>
 public record SiteGateway(
     string HardwareId,
     string InspectionState,
@@ -52,6 +66,11 @@ public record SiteGateway(
     string Shortname
 );
 
+/// <summary>
+/// Intrusion prevention system signature information.
+/// </summary>
+/// <param name="RulesCount">The number of rules in the signature set.</param>
+/// <param name="Type">The signature set type.</param>
 public record SiteIpsSignature(
     int RulesCount,
     string Type

--- a/src/UniFi.Net.SiteManager/Models/Site.cs
+++ b/src/UniFi.Net.SiteManager/Models/Site.cs
@@ -47,7 +47,7 @@ public record SiteStatistics(
     SiteGateway Gateway,
     IReadOnlyList<object> InternetIssues,
     SiteIspInfo IspInfo,
-    IReadOnlyDictionary<string, int> Percentages
+    IReadOnlyDictionary<string, double> Percentages
 );
 
 /// <summary>

--- a/src/UniFi.Net.SiteManager/SiteManagerClient.cs
+++ b/src/UniFi.Net.SiteManager/SiteManagerClient.cs
@@ -281,7 +281,7 @@ public class SiteManagerClient : ISiteManagerClient
         }
         var query = String.Join("&", queryParams.Where(kvp => !String.IsNullOrWhiteSpace(kvp.Key) && !String.IsNullOrWhiteSpace(queryParams[kvp.Key]))
             .SelectMany(kvp => queryParams[kvp.Key].Where(v => !String.IsNullOrWhiteSpace(v)).Select(v => $"{kvp.Key}={Uri.EscapeDataString(v!)}")));
-        return "?" + query;
+        return String.IsNullOrEmpty(query) ? String.Empty : "?" + query;
     }
 
     private static IHttpClientFactory CreateFactory(Uri host, string apiKey)

--- a/src/UniFi.Net.SiteManager/SiteManagerClient.cs
+++ b/src/UniFi.Net.SiteManager/SiteManagerClient.cs
@@ -16,7 +16,6 @@ public class SiteManagerClient : ISiteManagerClient
     private readonly IHttpClientFactory _httpClientFactory;
 
     private const string Version = "v1";
-    private const string EarlyAccess = "ea";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SiteManagerClient"/> class using an <see cref="IHttpClientFactory"/>.
@@ -62,7 +61,7 @@ public class SiteManagerClient : ISiteManagerClient
 
         Dictionary<string, StringValues> queryParams = new()
         {
-            ["page"] = pageSize.ToString(),
+            ["pageSize"] = pageSize?.ToString() ?? String.Empty,
             ["nextToken"] = nextToken ?? String.Empty
         };
 
@@ -84,7 +83,7 @@ public class SiteManagerClient : ISiteManagerClient
 
         Dictionary<string, StringValues> queryParams = new()
         {
-            ["page"] = pageSize.ToString(),
+            ["pageSize"] = pageSize?.ToString() ?? String.Empty,
             ["nextToken"] = nextToken ?? String.Empty
         };
 
@@ -110,7 +109,7 @@ public class SiteManagerClient : ISiteManagerClient
     /// <inheritdoc/>
     public Task<DataResponse<IReadOnlyList<IspMetric>>> GetIspMetricsAsync(MetricInterval type, DateTimeOffset? beginTimestamp = null, DateTimeOffset? endTimestamp = null, CancellationToken cancellationToken = default)
     {
-        string url = $"{EarlyAccess}/isp-metrics/{type}";
+        string url = $"{Version}/isp-metrics/{ToPathSegment(type)}";
 
         Dictionary<string, StringValues> queryParams = new()
         {
@@ -122,9 +121,9 @@ public class SiteManagerClient : ISiteManagerClient
     }
 
     /// <inheritdoc/>
-    public Task<DataResponse<IReadOnlyList<IspMetric>>> GetIspMetricsAsync(MetricInterval type, string? duration = null, CancellationToken cancellationToken = default)
+    public Task<DataResponse<IReadOnlyList<IspMetric>>> GetIspMetricsAsync(MetricInterval type, string duration, CancellationToken cancellationToken = default)
     {
-        string url = $"{EarlyAccess}/isp-metrics/{type}";
+        string url = $"{Version}/isp-metrics/{ToPathSegment(type)}";
 
         Dictionary<string, StringValues> queryParams = new()
         {
@@ -135,17 +134,17 @@ public class SiteManagerClient : ISiteManagerClient
     }
 
     /// <inheritdoc/>
-    public Task<DataResponse<IReadOnlyList<IspMetric>>> QueryIspMetricsAsync(MetricInterval type, IEnumerable<IspMetricsQuery> sites, CancellationToken cancellationToken = default)
+    public Task<DataResponse<IspMetricsQueryResult>> QueryIspMetricsAsync(MetricInterval type, IEnumerable<IspMetricsQuery> sites, CancellationToken cancellationToken = default)
     {
-        string url = $"{EarlyAccess}/isp-metrics/{type}/query";
+        string url = $"{Version}/isp-metrics/{ToPathSegment(type)}/query";
 
-        return PostJsonAsync<IEnumerable<IspMetricsQuery>, DataResponse<IReadOnlyList<IspMetric>>>(url, sites, cancellationToken);
+        return PostJsonAsync<IspMetricsQueryRequest, DataResponse<IspMetricsQueryResult>>(url, new IspMetricsQueryRequest(sites), cancellationToken);
     }
 
     /// <inheritdoc/>
     public Task<DataResponse<IReadOnlyList<BasicSDWanConfig>>> ListSDWanConfigsAsync(CancellationToken cancellationToken = default)
     {
-        const string url = $"{EarlyAccess}/sd-wan-configs";
+        const string url = $"{Version}/sd-wan-configs";
 
         return GetFromJsonAsync<DataResponse<IReadOnlyList<BasicSDWanConfig>>>(url, cancellationToken);
     }
@@ -153,7 +152,7 @@ public class SiteManagerClient : ISiteManagerClient
     /// <inheritdoc/>
     public Task<DataResponse<SDWanConfig>> GetSDWanConfigAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        string url = $"{EarlyAccess}/sd-wan-configs/{id}";
+        string url = $"{Version}/sd-wan-configs/{id}";
 
         return GetFromJsonAsync<DataResponse<SDWanConfig>>(url, cancellationToken);
     }
@@ -161,7 +160,7 @@ public class SiteManagerClient : ISiteManagerClient
     /// <inheritdoc/>
     public Task<DataResponse<SDWanConfigStatus>> GetSDWanConfigStatusAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        string url = $"{EarlyAccess}/sd-wan-configs/{id}/status";
+        string url = $"{Version}/sd-wan-configs/{id}/status";
 
         return GetFromJsonAsync<DataResponse<SDWanConfigStatus>>(url, cancellationToken);
     }
@@ -179,8 +178,6 @@ public class SiteManagerClient : ISiteManagerClient
             {
                 await ProcessErrorResponse(requestUri, responseMessage, cancellationToken);
             }
-
-            var content = await responseMessage.Content.ReadAsStringAsync(cancellationToken);
 
             var result = await responseMessage.Content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken);
 
@@ -256,6 +253,13 @@ public class SiteManagerClient : ISiteManagerClient
             throw new InvalidOperationException($"Error from {requestUri}: {response.ReasonPhrase}", ex);
         }
     }
+
+    private static string ToPathSegment(MetricInterval type) => type switch
+    {
+        MetricInterval.FiveMinutes => "5m",
+        MetricInterval.OneHour => "1h",
+        _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unknown metric interval.")
+    };
 
     private HttpClient GetClient()
     {

--- a/src/UniFi.Net.SiteManager/UniFi.Net.SiteManager.csproj
+++ b/src/UniFi.Net.SiteManager/UniFi.Net.SiteManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
@@ -10,8 +10,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>embedded</DebugType>
+    <DebugType>portable</DebugType>
     <Deterministic>true</Deterministic>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,14 +33,24 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="UniFi.Net.SiteManager.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="README.md" Pack="true" PackagePath="" />
     <Content Include="../../LICENSE" Link="LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.13" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.13" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.13" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <Import Project="..\UniFi.Net.Core\UniFi.Net.Core.projitems" Label="Shared" />

--- a/tests/UniFi.Net.SiteManager.Tests/SiteManagerModelTests.cs
+++ b/tests/UniFi.Net.SiteManager.Tests/SiteManagerModelTests.cs
@@ -1,0 +1,490 @@
+using System.Net;
+using System.Text.Json;
+using UniFi.Net.SiteManager.Models;
+
+namespace UniFi.Net.SiteManager.Tests;
+
+/// <summary>
+/// Verifies that Site Manager API models deserialize spec-shaped JSON using the same
+/// web defaults (camelCase, case-insensitive) that <c>ReadFromJsonAsync</c> applies.
+/// </summary>
+public class SiteManagerModelTests
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public void ListHosts_DeserializesHostAndUserData()
+    {
+        const string json = """
+        {
+            "data": [
+                {
+                    "id": "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                    "hardwareId": "eae0f123-0000-5111-b111-f833f56eade5",
+                    "type": "console",
+                    "ipAddress": "192.168.1.226",
+                    "owner": true,
+                    "isBlocked": false,
+                    "registrationTime": "2024-04-17T07:27:14Z",
+                    "lastConnectionStateChange": "2024-06-23T03:59:52Z",
+                    "latestBackupTime": "2024-06-22T11:55:10Z",
+                    "userData": {
+                        "apps": ["users"],
+                        "consoleGroupMembers": [
+                            {
+                                "mac": "F4E2C6C23F13",
+                                "role": "UNADOPTED",
+                                "roleAttributes": {
+                                    "applications": {
+                                        "network": { "owned": false, "required": true, "supported": true }
+                                    },
+                                    "candidateRoles": ["PRIMARY"],
+                                    "connectedState": "CONNECTED",
+                                    "connectedStateLastChanged": "2024-06-23T03:59:52Z"
+                                },
+                                "sysId": 58368
+                            }
+                        ],
+                        "controllers": ["network", "protect"],
+                        "email": "user@example.com",
+                        "features": {
+                            "deviceGroups": true,
+                            "floorplan": { "canEdit": true, "canView": true },
+                            "manageApplications": true,
+                            "notifications": true,
+                            "pion": true,
+                            "webrtc": { "iceRestart": true, "mediaStreams": true, "twoWayAudio": true }
+                        },
+                        "fullName": "UniFi User",
+                        "localId": "c74d461f-9a3b-4a48-b64f-3f9ae1d1341a",
+                        "permissions": { "network.management": ["admin"] },
+                        "role": "own",
+                        "roleId": "eb0ad29d-2eb2-4bd5-9dd1-a5b8bfba1b58",
+                        "status": "ACTIVE"
+                    },
+                    "reportedState": null
+                }
+            ],
+            "httpStatusCode": 200,
+            "traceId": "a7dc15e0eb4527142d7823515b15f87d",
+            "nextToken": "eyJ2IjoxfQ"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<PagedResponse<Host>>(json, Options);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.OK, response.HttpStatusCode);
+        Assert.Equal("a7dc15e0eb4527142d7823515b15f87d", response.TraceId);
+        Assert.Equal("eyJ2IjoxfQ", response.NextToken);
+        var host = Assert.Single(response.Data);
+        Assert.Equal("console", host.Type);
+        Assert.True(host.Owner);
+        Assert.Equal(new DateTimeOffset(2024, 4, 17, 7, 27, 14, TimeSpan.Zero), host.RegistrationTime);
+        Assert.Equal("user@example.com", host.UserData.Email);
+        var member = Assert.Single(host.UserData.ConsoleGroupMembers);
+        Assert.Equal(58368, member.SysId);
+        Assert.True(member.RoleAttributes.Applications["network"].Required);
+        Assert.True(host.UserData.Features.Floorplan.CanView);
+        Assert.Equal(["admin"], host.UserData.Permissions["network.management"]);
+    }
+
+    [Fact]
+    public void ListDevices_DeserializesHostWithDevices()
+    {
+        const string json = """
+        {
+            "data": [
+                {
+                    "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                    "hostName": "Dream Machine Special Edition",
+                    "devices": [
+                        {
+                            "id": "F4E2C6C23F13",
+                            "mac": "F4E2C6C23F13",
+                            "name": "Dream Machine Special Edition",
+                            "model": "UDM SE",
+                            "shortname": "UDMPROSE",
+                            "ip": "192.168.1.226",
+                            "productLine": "network",
+                            "status": "online",
+                            "version": "4.0.180",
+                            "firmwareStatus": "upToDate",
+                            "updateAvailable": null,
+                            "isConsole": true,
+                            "isManaged": true,
+                            "startupTime": "2024-06-19T13:41:43Z",
+                            "adoptionTime": null,
+                            "note": null,
+                            "uidb": {
+                                "guid": "0fd8c390-a0e8-4cb2-b93a-7b3051c83c46",
+                                "id": "e85485da-54c3-4906-8f19-3cef4116ff02",
+                                "images": { "default": "3008400039c483c496f4ad820242c447" }
+                            }
+                        }
+                    ],
+                    "updatedAt": "2024-06-23T03:59:52Z"
+                }
+            ],
+            "httpStatusCode": 200,
+            "traceId": "a7dc15e0eb4527142d7823515b15f87d",
+            "nextToken": null
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<PagedResponse<HostWithDevices>>(json, Options);
+
+        Assert.NotNull(response);
+        var host = Assert.Single(response.Data);
+        Assert.Equal("Dream Machine Special Edition", host.HostName);
+        Assert.Equal(new DateTimeOffset(2024, 6, 23, 3, 59, 52, TimeSpan.Zero), host.UpdatedAt);
+        var device = Assert.Single(host.Devices);
+        Assert.Equal("UDMPROSE", device.ShortName);
+        Assert.True(device.IsConsole);
+        Assert.Null(device.UpdateAvailable);
+        Assert.Equal("3008400039c483c496f4ad820242c447", device.Uidb.Images["default"]);
+    }
+
+    [Fact]
+    public void ListSites_DeserializesSite()
+    {
+        const string json = """
+        {
+            "data": [
+                {
+                    "siteId": "661900ae6aec8f548d49fd54",
+                    "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                    "meta": {
+                        "desc": "Default",
+                        "gatewayMac": "f4:e2:c6:c2:3f:13",
+                        "name": "default",
+                        "timezone": "Europe/Lisbon"
+                    },
+                    "statistics": {
+                        "counts": {
+                            "criticalNotificationCount": 0,
+                            "gatewayDevice": 1,
+                            "guestClient": 0,
+                            "totalDevice": 5,
+                            "wifiClient": 24
+                        },
+                        "gateway": {
+                            "hardwareId": "eae0f123-0000-5111-b111-f833f56eade5",
+                            "inspectionState": "off",
+                            "ipsMode": "detection",
+                            "ipsSignature": { "rulesCount": 43416, "type": "ET" },
+                            "shortname": "UDMPROSE"
+                        },
+                        "internetIssues": [],
+                        "ispInfo": { "name": "Vodafone", "organization": "Vodafone Portugal" },
+                        "percentages": { "txRetry": 2, "wanUptime": 99 }
+                    },
+                    "permission": "admin",
+                    "isOwner": false
+                }
+            ],
+            "httpStatusCode": 200,
+            "traceId": "0e4d2f34a41b8b371abd0f8305506327",
+            "nextToken": null
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<PagedResponse<Site>>(json, Options);
+
+        Assert.NotNull(response);
+        var site = Assert.Single(response.Data);
+        Assert.Equal("661900ae6aec8f548d49fd54", site.SiteId);
+        Assert.Equal("Europe/Lisbon", site.Meta.TimeZone);
+        Assert.Equal(5, site.Statistics.Counts["totalDevice"]);
+        Assert.Equal(43416, site.Statistics.Gateway.IpsSignature.RulesCount);
+        Assert.Equal("Vodafone", site.Statistics.IspInfo.Name);
+        Assert.Equal(99, site.Statistics.Percentages["wanUptime"]);
+        Assert.Equal("admin", site.Permission);
+    }
+
+    [Fact]
+    public void GetIspMetrics_DeserializesSnakeCaseKbpsFields()
+    {
+        const string json = """
+        {
+            "data": [
+                {
+                    "metricType": "5m",
+                    "periods": [
+                        {
+                            "data": {
+                                "wan": {
+                                    "avgLatency": 5,
+                                    "download_kbps": 118000,
+                                    "downtime": 0,
+                                    "ispAsn": "3352",
+                                    "ispName": "Vodafone",
+                                    "maxLatency": 9,
+                                    "packetLoss": 0,
+                                    "upload_kbps": 61000,
+                                    "uptime": 100
+                                }
+                            },
+                            "metricTime": "2024-06-23T09:00:00Z",
+                            "version": "1"
+                        }
+                    ],
+                    "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                    "siteId": "661900ae6aec8f548d49fd54"
+                }
+            ],
+            "httpStatusCode": 200,
+            "traceId": "d54e6a6f7fe37b558f30947db2b09b45"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<DataResponse<IReadOnlyList<IspMetric>>>(json, Options);
+
+        Assert.NotNull(response);
+        var metric = Assert.Single(response.Data);
+        Assert.Equal("5m", metric.MetricType);
+        var wan = Assert.Single(metric.Periods).Data.Wan;
+        // Regression: these fields are snake_case on the wire and need explicit mappings.
+        Assert.Equal(118000, wan.DownloadKbps);
+        Assert.Equal(61000, wan.UploadKbps);
+        Assert.Equal(5, wan.AvgLatency);
+        Assert.Equal("Vodafone", wan.IspName);
+    }
+
+    [Fact]
+    public void QueryIspMetrics_DeserializesMetricsWrapper()
+    {
+        const string json = """
+        {
+            "data": {
+                "metrics": [
+                    {
+                        "metricType": "1h",
+                        "periods": [],
+                        "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                        "siteId": "661900ae6aec8f548d49fd54"
+                    }
+                ],
+                "message": "partial data returned",
+                "status": "partialSuccess"
+            },
+            "httpStatusCode": 200,
+            "traceId": "d54e6a6f7fe37b558f30947db2b09b45"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<DataResponse<IspMetricsQueryResult>>(json, Options);
+
+        Assert.NotNull(response);
+        var metric = Assert.Single(response.Data.Metrics);
+        Assert.Equal("1h", metric.MetricType);
+        Assert.Equal("partial data returned", response.Data.Message);
+        Assert.Equal("partialSuccess", response.Data.Status);
+    }
+
+    [Fact]
+    public void GetSDWanConfig_DeserializesCamelCaseEnums()
+    {
+        const string json = """
+        {
+            "data": {
+                "id": "6572628f-4be3-4e73-a233-a684dab3ac96",
+                "name": "SD-WAN config",
+                "type": "sdwan-hbsp",
+                "variant": "distributed",
+                "settings": {
+                    "hubsInterconnect": true,
+                    "spokeToHubTunnelsMode": "maxResiliency",
+                    "spokesAutoScaleAndNatEnabled": true,
+                    "spokesAutoScaleAndNatRange": "172.16.0.0/12",
+                    "spokesIsolate": false,
+                    "spokeStandardSettingsEnabled": false,
+                    "spokeStandardSettingsValues": null,
+                    "spokeToHubRouting": "geo"
+                },
+                "hubs": [
+                    {
+                        "id": "6572628f-4be3-4e73-a233-a684dab3ac97",
+                        "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                        "siteId": "661900ae6aec8f548d49fd54",
+                        "networkIds": ["6633a11c9a71ed6b4f6ab432"],
+                        "routes": ["10.0.0.0/24"],
+                        "primaryWan": "WAN",
+                        "wanFailover": true
+                    }
+                ],
+                "spokes": [
+                    {
+                        "id": "6572628f-4be3-4e73-a233-a684dab3ac98",
+                        "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F8",
+                        "siteId": "661900ae6aec8f548d49fd55",
+                        "networkIds": [],
+                        "routes": [],
+                        "primaryWan": "WAN2",
+                        "wanFailover": false,
+                        "hubsPriority": ["6572628f-4be3-4e73-a233-a684dab3ac97"]
+                    }
+                ]
+            },
+            "httpStatusCode": 200,
+            "traceId": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<DataResponse<SDWanConfig>>(json, Options);
+
+        Assert.NotNull(response);
+        var config = response.Data;
+        Assert.Equal(SDWanVariant.Distributed, config.Variant);
+        Assert.Equal(SpokeToHubTunnelsMode.MaxResiliency, config.Settings.SpokeToHubTunnelsMode);
+        Assert.Equal(SpokeToHubRouting.Geo, config.Settings.SpokeToHubRouting);
+        var hub = Assert.Single(config.Hubs);
+        Assert.True(hub.WanFailover);
+        var spoke = Assert.Single(config.Spokes);
+        Assert.Equal(["6572628f-4be3-4e73-a233-a684dab3ac97"], spoke.HubsPriority);
+    }
+
+    [Fact]
+    public void GetSDWanConfigStatus_DeserializesStatusEnums()
+    {
+        const string json = """
+        {
+            "data": {
+                "id": "6572628f-4be3-4e73-a233-a684dab3ac96",
+                "fingerprint": "029b46b1cf46ba7f",
+                "updatedAt": 1719140392,
+                "hubs": [
+                    {
+                        "id": "6572628f-4be3-4e73-a233-a684dab3ac97",
+                        "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                        "siteId": "661900ae6aec8f548d49fd54",
+                        "name": "Hub 1",
+                        "primaryWanStatus": { "ip": "10.0.0.1", "latency": 5, "internetIssues": [], "wanId": "wan" },
+                        "secondaryWanStatus": { "ip": "10.0.0.2", "latency": null, "internetIssues": null, "wanId": "wan2" },
+                        "errors": [],
+                        "warnings": [],
+                        "numberOfTunnelsUsedByOtherFeatures": 0,
+                        "networks": [
+                            { "networkId": "6633a11c9a71ed6b4f6ab432", "name": "Default", "errors": [], "warnings": [] }
+                        ],
+                        "routes": [],
+                        "applyStatus": "createFailed"
+                    }
+                ],
+                "spokes": [
+                    {
+                        "id": "6572628f-4be3-4e73-a233-a684dab3ac98",
+                        "hostId": "900A6F00301E000000000626123456780000000004018100000000078A5941F8",
+                        "siteId": "661900ae6aec8f548d49fd55",
+                        "name": "Spoke 1",
+                        "primaryWanStatus": { "ip": "10.0.1.1", "latency": 12, "internetIssues": [], "wanId": "wan" },
+                        "secondaryWanStatus": { "ip": "10.0.1.2", "latency": null, "internetIssues": [], "wanId": "wan2" },
+                        "errors": [],
+                        "warnings": [],
+                        "numberOfTunnelsUsedByOtherFeatures": 1,
+                        "networks": [],
+                        "routes": [
+                            { "routeValue": "10.0.0.0/24", "errors": [], "warnings": [] }
+                        ],
+                        "connections": [
+                            {
+                                "hubId": "6572628f-4be3-4e73-a233-a684dab3ac97",
+                                "tunnels": [
+                                    { "spokeWanId": "wan", "hubWanId": "wan", "status": "connected" }
+                                ]
+                            }
+                        ],
+                        "applyStatus": "ok"
+                    }
+                ],
+                "lastGeneratedAt": 1719140300,
+                "generateStatus": "GENERATE_FAILED",
+                "errors": [],
+                "warnings": []
+            },
+            "httpStatusCode": 200,
+            "traceId": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<DataResponse<SDWanConfigStatus>>(json, Options);
+
+        Assert.NotNull(response);
+        var status = response.Data;
+        Assert.Equal(GenerateStatus.GenerateFailed, status.GenerateStatus);
+        var hub = Assert.Single(status.Hubs);
+        Assert.Equal(ApplyStatus.CreateFailed, hub.ApplyStatus);
+        Assert.Null(hub.SecondaryWanStatus.Latency);
+        var spoke = Assert.Single(status.Spokes);
+        Assert.Equal(ApplyStatus.Ok, spoke.ApplyStatus);
+        var connection = Assert.Single(spoke.Connections);
+        var tunnel = Assert.Single(connection.Tunnels);
+        Assert.Equal(TunnelStatus.Connected, tunnel.Status);
+        Assert.Equal("10.0.0.0/24", Assert.Single(spoke.Routes).RouteValue);
+    }
+
+    [Fact]
+    public void ListSDWanConfigs_DeserializesBasicConfig()
+    {
+        const string json = """
+        {
+            "data": [
+                { "id": "6572628f-4be3-4e73-a233-a684dab3ac96", "name": "SD-WAN config", "type": "sdwan-hbsp" }
+            ],
+            "httpStatusCode": 200,
+            "traceId": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<DataResponse<IReadOnlyList<BasicSDWanConfig>>>(json, Options);
+
+        Assert.NotNull(response);
+        var config = Assert.Single(response.Data);
+        Assert.Equal(Guid.Parse("6572628f-4be3-4e73-a233-a684dab3ac96"), config.Id);
+        Assert.Equal("sdwan-hbsp", config.Type);
+    }
+
+    [Fact]
+    public void ErrorResponse_Deserializes()
+    {
+        const string json = """
+        {
+            "httpStatusCode": 401,
+            "code": "UNAUTHORIZED",
+            "message": "unauthorized",
+            "traceId": "b30d1554e0873f4d70595cd772e0f4aa"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<ErrorResponse>(json, Options);
+
+        Assert.NotNull(response);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.HttpStatusCode);
+        Assert.Equal("UNAUTHORIZED", response.Code);
+        Assert.Equal("unauthorized", response.Message);
+        Assert.Equal("b30d1554e0873f4d70595cd772e0f4aa", response.TraceId);
+    }
+
+    [Fact]
+    public void IspMetricsQueryRequest_SerializesSitesWrapper()
+    {
+        var request = new IspMetricsQueryRequest(
+        [
+            new IspMetricsQuery
+            {
+                BeginTimestamp = new DateTimeOffset(2024, 6, 22, 0, 0, 0, TimeSpan.Zero),
+                EndTimestamp = new DateTimeOffset(2024, 6, 23, 0, 0, 0, TimeSpan.Zero),
+                HostId = "900A6F00301E000000000626123456780000000004018100000000078A5941F7",
+                SiteId = "661900ae6aec8f548d49fd54"
+            }
+        ]);
+
+        var json = JsonSerializer.Serialize(request, Options);
+
+        using var document = JsonDocument.Parse(json);
+        var sites = document.RootElement.GetProperty("sites");
+        var site = Assert.Single(sites.EnumerateArray().ToArray());
+        Assert.Equal("661900ae6aec8f548d49fd54", site.GetProperty("siteId").GetString());
+        Assert.Equal("2024-06-22T00:00:00+00:00", site.GetProperty("beginTimestamp").GetString());
+    }
+}

--- a/tests/UniFi.Net.SiteManager.Tests/SiteManagerModelTests.cs
+++ b/tests/UniFi.Net.SiteManager.Tests/SiteManagerModelTests.cs
@@ -177,7 +177,7 @@ public class SiteManagerModelTests
                         },
                         "internetIssues": [],
                         "ispInfo": { "name": "Vodafone", "organization": "Vodafone Portugal" },
-                        "percentages": { "txRetry": 2, "wanUptime": 99 }
+                        "percentages": { "txRetry": 2.5, "wanUptime": 99.98 }
                     },
                     "permission": "admin",
                     "isOwner": false
@@ -198,7 +198,9 @@ public class SiteManagerModelTests
         Assert.Equal(5, site.Statistics.Counts["totalDevice"]);
         Assert.Equal(43416, site.Statistics.Gateway.IpsSignature.RulesCount);
         Assert.Equal("Vodafone", site.Statistics.IspInfo.Name);
-        Assert.Equal(99, site.Statistics.Percentages["wanUptime"]);
+        // Regression: the live API returns fractional percentages (e.g. txRetry 2.5).
+        Assert.Equal(2.5, site.Statistics.Percentages["txRetry"]);
+        Assert.Equal(99.98, site.Statistics.Percentages["wanUptime"]);
         Assert.Equal("admin", site.Permission);
     }
 

--- a/tests/UniFi.Net.SiteManager.Tests/SiteManagerModelTests.cs
+++ b/tests/UniFi.Net.SiteManager.Tests/SiteManagerModelTests.cs
@@ -121,6 +121,25 @@ public class SiteManagerModelTests
                                 "id": "e85485da-54c3-4906-8f19-3cef4116ff02",
                                 "images": { "default": "3008400039c483c496f4ad820242c447" }
                             }
+                        },
+                        {
+                            "id": "784558E80E01",
+                            "mac": "784558E80E01",
+                            "name": "Third Party Device",
+                            "model": null,
+                            "shortname": null,
+                            "ip": "192.168.1.50",
+                            "productLine": null,
+                            "status": "offline",
+                            "version": null,
+                            "firmwareStatus": null,
+                            "updateAvailable": null,
+                            "isConsole": false,
+                            "isManaged": false,
+                            "startupTime": null,
+                            "adoptionTime": null,
+                            "note": null,
+                            "uidb": { "guid": null, "id": null, "images": null }
                         }
                     ],
                     "updatedAt": "2024-06-23T03:59:52Z"
@@ -138,11 +157,20 @@ public class SiteManagerModelTests
         var host = Assert.Single(response.Data);
         Assert.Equal("Dream Machine Special Edition", host.HostName);
         Assert.Equal(new DateTimeOffset(2024, 6, 23, 3, 59, 52, TimeSpan.Zero), host.UpdatedAt);
-        var device = Assert.Single(host.Devices);
+        Assert.Equal(2, host.Devices.Count);
+        var device = host.Devices[0];
         Assert.Equal("UDMPROSE", device.ShortName);
         Assert.True(device.IsConsole);
         Assert.Null(device.UpdateAvailable);
+        Assert.NotNull(device.Uidb);
+        Assert.NotNull(device.Uidb.Images);
         Assert.Equal("3008400039c483c496f4ad820242c447", device.Uidb.Images["default"]);
+        // Regression: third-party/unadopted devices report null uidb fields and startup time.
+        var thirdParty = host.Devices[1];
+        Assert.Null(thirdParty.StartupTime);
+        Assert.NotNull(thirdParty.Uidb);
+        Assert.Null(thirdParty.Uidb.Guid);
+        Assert.Null(thirdParty.Uidb.Images);
     }
 
     [Fact]

--- a/tests/UniFi.Net.SiteManager.Tests/UniFi.Net.SiteManager.Tests.csproj
+++ b/tests/UniFi.Net.SiteManager.Tests/UniFi.Net.SiteManager.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\UniFi.Net.SiteManager\UniFi.Net.SiteManager.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/UniFi.Net.TestHarness/App.cs
+++ b/tests/UniFi.Net.TestHarness/App.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting;
 using UniFi.Net.TestHarness.Network;
 using UniFi.Net.TestHarness.SiteManager;
 
@@ -8,11 +8,15 @@ internal class App(NetworkClient networkClient, SiteManagerClient siteManagerCli
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        int action = 0;
-
-        while (action >= 0 && !cancellationToken.IsCancellationRequested)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            action = PrintMenu();
+            var action = PromptOption(
+                """
+                UniFi Client Test Harness
+                Choose your API
+                """,
+                ["Network API", "Site Manager API", "Access API"],
+                "Exit");
 
             switch (action)
             {
@@ -24,15 +28,11 @@ internal class App(NetworkClient networkClient, SiteManagerClient siteManagerCli
                     break;
                 case 3:
                     WriteLine("Access API is not implemented yet.");
-                    ReadKey();
+                    PressAnyKeyToContinue();
                     break;
-                case 4:
+                case 0:
                     Environment.Exit(0);
                     break;
-                default:
-                    WriteLine("Invalid option, please try again.");
-                    ReadKey();
-                    continue;
             }
         }
     }
@@ -40,31 +40,5 @@ internal class App(NetworkClient networkClient, SiteManagerClient siteManagerCli
     public Task StopAsync(CancellationToken cancellationToken)
     {
         return Task.CompletedTask;
-    }
-
-    private static int PrintMenu()
-    {
-        Clear();
-        WriteLine("UniFi Client Test Harness");
-        WriteLine("-------------------------");
-        WriteLine("Choose your API");
-        WriteLine("1. Network API");
-        WriteLine("2. Site Manager API");
-        WriteLine("3. Access API ");
-        WriteLine("4. Exit");
-        Write("Select an option: ");
-
-        var input = ReadKey();
-
-        WriteLine();
-
-        if (!Int32.TryParse(input.KeyChar.ToString(), out var option) || option > 4)
-        {
-            WriteLine("Invalid option, please try again.");
-            return -1;
-
-        }
-
-        return option;
     }
 }

--- a/tests/UniFi.Net.TestHarness/Extensions/ConsoleExtensions.cs
+++ b/tests/UniFi.Net.TestHarness/Extensions/ConsoleExtensions.cs
@@ -6,7 +6,10 @@ internal static class ConsoleExtensions
         public static void PressAnyKeyToContinue()
         {
             Console.WriteLine();
+            var original = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.DarkGray;
             Console.WriteLine("Press any key to continue...");
+            Console.ForegroundColor = original;
             Console.ReadKey(true);
         }
     }
@@ -23,37 +26,68 @@ internal static class ConsoleExtensions
     }
 
     /// <summary>
+    /// Writes a cyan heading with an underline.
+    /// </summary>
+    public static void WriteHeading(string heading)
+    {
+        var original = Console.ForegroundColor;
+        var lines = heading.Split('\n');
+
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine(lines[0]);
+
+        Console.ForegroundColor = ConsoleColor.DarkCyan;
+        foreach (var line in lines.Skip(1))
+        {
+            Console.WriteLine(line);
+        }
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine(new string('-', Math.Max(8, lines.Max(l => l.Length))));
+        Console.ForegroundColor = original;
+    }
+
+    /// <summary>
     /// Clears the console, renders a titled numbered menu and returns the chosen
     /// 1-based option, or 0 for the back option. Re-prompts until the input is valid.
-    /// Handles any number of options (input is read as a full line).
+    /// Menus with up to nine options take a single key press; larger menus read a full line.
     /// </summary>
     public static int PromptOption(string title, IReadOnlyList<string> options, string backLabel = "Back")
     {
         while (true)
         {
             Console.Clear();
-            foreach (var line in title.Split('\n'))
-            {
-                Console.WriteLine(line);
-            }
-            Console.WriteLine(new string('-', Math.Max(8, title.Split('\n').Max(l => l.Length))));
+            WriteHeading(title);
+
+            var original = Console.ForegroundColor;
             for (int i = 0; i < options.Count; i++)
             {
-                Console.WriteLine($"{i + 1}. {options[i]}");
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write($"{i + 1}. ");
+                Console.ForegroundColor = original;
+                Console.WriteLine(options[i]);
             }
+            Console.ForegroundColor = ConsoleColor.DarkGray;
             Console.WriteLine($"0. {backLabel}");
-            Console.Write("Select an option (and press enter): ");
+            Console.ForegroundColor = original;
 
-            var input = Console.ReadLine();
+            int? choice;
+            if (options.Count <= 9)
+            {
+                Console.Write("Select an option: ");
+                choice = Int32.TryParse(Console.ReadKey(true).KeyChar.ToString(), out var key) ? key : null;
+            }
+            else
+            {
+                Console.Write("Select an option (and press enter): ");
+                choice = Int32.TryParse(Console.ReadLine(), out var line) ? line : null;
+            }
 
-            if (Int32.TryParse(input, out var option) && option >= 0 && option <= options.Count)
+            if (choice is int option && option >= 0 && option <= options.Count)
             {
                 Console.WriteLine();
                 return option;
             }
-
-            WriteError("Invalid option, please try again.");
-            Console.PressAnyKeyToContinue();
         }
     }
 

--- a/tests/UniFi.Net.TestHarness/Extensions/ConsoleExtensions.cs
+++ b/tests/UniFi.Net.TestHarness/Extensions/ConsoleExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace UniFi.Net.TestHarness;
+namespace UniFi.Net.TestHarness;
 internal static class ConsoleExtensions
 {
     extension(Console)
@@ -9,5 +9,69 @@ internal static class ConsoleExtensions
             Console.WriteLine("Press any key to continue...");
             Console.ReadKey(true);
         }
+    }
+
+    /// <summary>
+    /// Writes an error message in red.
+    /// </summary>
+    public static void WriteError(string message)
+    {
+        var original = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine(message);
+        Console.ForegroundColor = original;
+    }
+
+    /// <summary>
+    /// Clears the console, renders a titled numbered menu and returns the chosen
+    /// 1-based option, or 0 for the back option. Re-prompts until the input is valid.
+    /// Handles any number of options (input is read as a full line).
+    /// </summary>
+    public static int PromptOption(string title, IReadOnlyList<string> options, string backLabel = "Back")
+    {
+        while (true)
+        {
+            Console.Clear();
+            foreach (var line in title.Split('\n'))
+            {
+                Console.WriteLine(line);
+            }
+            Console.WriteLine(new string('-', Math.Max(8, title.Split('\n').Max(l => l.Length))));
+            for (int i = 0; i < options.Count; i++)
+            {
+                Console.WriteLine($"{i + 1}. {options[i]}");
+            }
+            Console.WriteLine($"0. {backLabel}");
+            Console.Write("Select an option (and press enter): ");
+
+            var input = Console.ReadLine();
+
+            if (Int32.TryParse(input, out var option) && option >= 0 && option <= options.Count)
+            {
+                Console.WriteLine();
+                return option;
+            }
+
+            WriteError("Invalid option, please try again.");
+            Console.PressAnyKeyToContinue();
+        }
+    }
+
+    /// <summary>
+    /// Clears the console, renders a numbered selection list and returns the chosen item,
+    /// or <see langword="null"/> if the user backs out (or the list is empty).
+    /// </summary>
+    public static T? SelectItem<T>(string title, IReadOnlyList<T> items, Func<T, string> label) where T : class
+    {
+        if (items.Count == 0)
+        {
+            Console.WriteLine("No items found.");
+            Console.PressAnyKeyToContinue();
+            return null;
+        }
+
+        var option = PromptOption(title, [.. items.Select(label)]);
+
+        return option == 0 ? null : items[option - 1];
     }
 }

--- a/tests/UniFi.Net.TestHarness/Network/Clients.cs
+++ b/tests/UniFi.Net.TestHarness/Network/Clients.cs
@@ -41,8 +41,14 @@ public partial class NetworkClient
 
                 break;
             case 2:
-                WriteLine("Getting Client Details...");
-                // Call method to get client details
+                if (!SelectedSiteCheck()) return;
+                if (SelectedClient is null)
+                {
+                    WriteLine("No client selected. Please select a client first (List Clients).");
+                    break;
+                }
+                var clientDetails = await uniFiClient.GetClient(SelectedSite!.Id, SelectedClient.Id, cancellationToken);
+                PrintClient(clientDetails);
                 break;
             default:
                 WriteLine("Invalid client action, please try again.");

--- a/tests/UniFi.Net.TestHarness/Network/NetworkClient.cs
+++ b/tests/UniFi.Net.TestHarness/Network/NetworkClient.cs
@@ -93,51 +93,47 @@ public partial class NetworkClient(INetworkClient uniFiClient)
 
     private (int, object?) PrintMenu()
     {
-        Clear();
-        WriteLine("Unifi Network Client Test Harness");
-        WriteLine("-------------------------");
+        var title = "Unifi Network Client Test Harness";
         if (SelectedSite is not null)
         {
-            WriteLine($"Current site is {SelectedSite.Name}");
-            WriteLine("-------------------------");
+            title += $"\nCurrent site is {SelectedSite.Name}";
         }
         if (SelectedDevice is not null)
         {
-            WriteLine($"Current device is {SelectedDevice.Name}");
-            WriteLine("-------------------------");
+            title += $"\nCurrent device is {SelectedDevice.Name}";
         }
         if (SelectedClient is not null)
         {
-            WriteLine($"Current client is {SelectedClient.Name}");
-            WriteLine("-------------------------");
+            title += $"\nCurrent client is {SelectedClient.Name}";
         }
-        WriteLine("1. Info");
-        WriteLine("2. Sites");
-        WriteLine("3. Devices");
-        WriteLine("4. Clients");
-        WriteLine("5. Port Actions");
-        WriteLine("6. Device Actions");
-        WriteLine("7. Client Actions");
-        WriteLine("8. Vouchers");
-        WriteLine("9. All read endpoints");
-        WriteLine($"{NetworkExitOption}. Main menu");
-        Write("Select an option: ");
 
-        var input = ReadKey();
-        WriteLine();
+        var option = PromptOption(
+            title,
+            [
+                "Info",
+                "Sites",
+                "Devices",
+                "Clients",
+                "Port Actions",
+                "Device Actions",
+                "Client Actions",
+                "Vouchers",
+                "All read endpoints",
+            ],
+            "Main menu");
 
-        return input.KeyChar switch
+        return option switch
         {
-            '1' => (1, null),
-            '2' => (2, PrintSitesMenu()), // List Devices
-            '3' => (3, PrintDevicesMenu()), // Get Device Details
-            '4' => (4, PrintClientsMenu()), // List Clients
-            '5' => (5, PrintPortActionsMenu()), // Port Actions
-            '6' => (6, PrintDeviceActionsMenu()), // Device Actions
-            '7' => (7, PrintClientActionsMenu()),
-            '8' => (8, PrintVouchersMenu()),
-            '9' => (9, null), // All read endpoints
-            '0' => (NetworkExitOption, null), // Exit
+            1 => (1, null),
+            2 => (2, PrintSitesMenu()),
+            3 => (3, PrintDevicesMenu()),
+            4 => (4, PrintClientsMenu()),
+            5 => (5, PrintPortActionsMenu()),
+            6 => (6, PrintDeviceActionsMenu()),
+            7 => (7, PrintClientActionsMenu()),
+            8 => (8, PrintVouchersMenu()),
+            9 => (9, null), // All read endpoints
+            0 => (NetworkExitOption, null), // Back to main menu
             _ => (-1, null)
         };
     }

--- a/tests/UniFi.Net.TestHarness/Network/NetworkClient.cs
+++ b/tests/UniFi.Net.TestHarness/Network/NetworkClient.cs
@@ -5,26 +5,42 @@ namespace UniFi.Net.TestHarness.Network;
 
 public partial class NetworkClient(INetworkClient uniFiClient)
 {
-    private const byte NetworkExitOption = 9;
+    private const byte NetworkExitOption = 0;
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        var sites = await uniFiClient.ListSites(cancellationToken: cancellationToken);
-
-        SelectedSite = sites.Data.Count > 0 ? sites.Data[0] : null;
-
-        if (SelectedSite != null)
+        try
         {
-            var devices = await uniFiClient.ListDevices(SelectedSite.Id, null, null, 200, cancellationToken);
-            SelectedDevice = devices.Data.Count > 0 ? devices.Data[0] : null;
+            var sites = await uniFiClient.ListSites(cancellationToken: cancellationToken);
+
+            SelectedSite = sites.Data.Count > 0 ? sites.Data[0] : null;
+
+            if (SelectedSite != null)
+            {
+                var devices = await uniFiClient.ListDevices(SelectedSite.Id, null, null, 200, cancellationToken);
+                SelectedDevice = devices.Data.Count > 0 ? devices.Data[0] : null;
+            }
+        }
+        catch (Exception ex)
+        {
+            WriteError($"Could not list sites/devices: {ex.Message}");
+            PressAnyKeyToContinue();
         }
 
-        (int Primary, object? Action) action = (0, null);
+        (int Primary, object? Action) action = (-1, null);
         while (action.Primary != NetworkExitOption && !cancellationToken.IsCancellationRequested)
         {
             action = PrintMenu();
 
-            await DoAction(action, cancellationToken);
+            try
+            {
+                await DoAction(action, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                WriteError($"Error: {ex.Message}");
+                PressAnyKeyToContinue();
+            }
         }
     }
 
@@ -55,6 +71,9 @@ public partial class NetworkClient(INetworkClient uniFiClient)
                 break;
             case 8:
                 await DoVouchers((int)action.Action!, cancellationToken);
+                break;
+            case 9:
+                await DoReads(cancellationToken);
                 break;
             case NetworkExitOption:
                 break;
@@ -100,6 +119,7 @@ public partial class NetworkClient(INetworkClient uniFiClient)
         WriteLine("6. Device Actions");
         WriteLine("7. Client Actions");
         WriteLine("8. Vouchers");
+        WriteLine("9. All read endpoints");
         WriteLine($"{NetworkExitOption}. Main menu");
         Write("Select an option: ");
 
@@ -116,7 +136,8 @@ public partial class NetworkClient(INetworkClient uniFiClient)
             '6' => (6, PrintDeviceActionsMenu()), // Device Actions
             '7' => (7, PrintClientActionsMenu()),
             '8' => (8, PrintVouchersMenu()),
-            (char)NetworkExitOption => (NetworkExitOption, null), // Exit
+            '9' => (9, null), // All read endpoints
+            '0' => (NetworkExitOption, null), // Exit
             _ => (-1, null)
         };
     }

--- a/tests/UniFi.Net.TestHarness/Network/Reads.cs
+++ b/tests/UniFi.Net.TestHarness/Network/Reads.cs
@@ -1,0 +1,111 @@
+using UniFi.Net.Network.Models;
+
+namespace UniFi.Net.TestHarness.Network;
+
+public partial class NetworkClient
+{
+    /// <summary>
+    /// A data-driven browser over every read endpoint of the Network API. List endpoints print
+    /// their items; get-by-id endpoints fetch the first item from the corresponding list so
+    /// every read can be exercised without bespoke selection UI.
+    /// </summary>
+    private async Task DoReads(CancellationToken cancellationToken)
+    {
+        (string Name, Func<CancellationToken, Task> Run)[] entries =
+        [
+            ("Application info", async ct => WriteLine(await uniFiClient.GetApplicationInfo(ct))),
+            ("Sites", async ct => PrintPaged(await uniFiClient.ListSites(cancellationToken: ct))),
+            ("Devices", async ct => PrintPaged(await uniFiClient.ListDevices(RequireSite(), cancellationToken: ct))),
+            ("Device (selected)", async ct => WriteLine(await uniFiClient.GetDevice(RequireSite(), RequireDevice(), ct))),
+            ("Device statistics (selected)", async ct => WriteLine(await uniFiClient.GetDeviceStatistics(RequireSite(), RequireDevice(), ct))),
+            ("Pending devices", async ct => PrintPaged(await uniFiClient.ListPendingDevices(cancellationToken: ct))),
+            ("Clients", async ct => PrintPaged(await uniFiClient.ListClients(RequireSite(), cancellationToken: ct))),
+            ("Networks", async ct => PrintPaged(await uniFiClient.ListNetworks(RequireSite(), cancellationToken: ct))),
+            ("Network (first)", async ct => WriteLine(await uniFiClient.GetNetwork(RequireSite(), await FirstId(uniFiClient.ListNetworks(RequireSite(), limit: 1, cancellationToken: ct), n => n.Id), ct))),
+            ("Network references (first)", async ct => WriteLine(await uniFiClient.GetNetworkReferences(RequireSite(), await FirstId(uniFiClient.ListNetworks(RequireSite(), limit: 1, cancellationToken: ct), n => n.Id), ct))),
+            ("WiFi broadcasts", async ct => PrintPaged(await uniFiClient.ListWifiBroadcasts(RequireSite(), cancellationToken: ct))),
+            ("WiFi broadcast (first)", async ct => WriteLine(await uniFiClient.GetWifiBroadcast(RequireSite(), await FirstId(uniFiClient.ListWifiBroadcasts(RequireSite(), limit: 1, cancellationToken: ct), w => w.Id), ct))),
+            ("LAGs", async ct => PrintPaged(await uniFiClient.ListLags(RequireSite(), cancellationToken: ct))),
+            ("LAG (first)", async ct => WriteLine(await uniFiClient.GetLag(RequireSite(), await FirstId(uniFiClient.ListLags(RequireSite(), limit: 1, cancellationToken: ct), l => l.Id), ct))),
+            ("MC-LAG domains", async ct => PrintPaged(await uniFiClient.ListMcLagDomains(RequireSite(), cancellationToken: ct))),
+            ("MC-LAG domain (first)", async ct => WriteLine(await uniFiClient.GetMcLagDomain(RequireSite(), await FirstId(uniFiClient.ListMcLagDomains(RequireSite(), limit: 1, cancellationToken: ct), d => d.Id), ct))),
+            ("Switch stacks", async ct => PrintPaged(await uniFiClient.ListSwitchStacks(RequireSite(), cancellationToken: ct))),
+            ("Switch stack (first)", async ct => WriteLine(await uniFiClient.GetSwitchStack(RequireSite(), await FirstId(uniFiClient.ListSwitchStacks(RequireSite(), limit: 1, cancellationToken: ct), s => s.Id), ct))),
+            ("Firewall zones", async ct => PrintPaged(await uniFiClient.ListFirewallZones(RequireSite(), cancellationToken: ct))),
+            ("Firewall zone (first)", async ct => WriteLine(await uniFiClient.GetFirewallZone(RequireSite(), await FirstId(uniFiClient.ListFirewallZones(RequireSite(), limit: 1, cancellationToken: ct), z => z.Id), ct))),
+            ("Firewall policies", async ct => PrintPaged(await uniFiClient.ListFirewallPolicies(RequireSite(), cancellationToken: ct))),
+            ("Firewall policy (first)", async ct => WriteLine(await uniFiClient.GetFirewallPolicy(RequireSite(), await FirstId(uniFiClient.ListFirewallPolicies(RequireSite(), limit: 1, cancellationToken: ct), p => p.Id), ct))),
+            ("Firewall policy ordering (first two zones)", async ct =>
+            {
+                var zones = await uniFiClient.ListFirewallZones(RequireSite(), limit: 2, cancellationToken: ct);
+                if (zones.Data.Count < 2) throw new InvalidOperationException("Need at least two firewall zones.");
+                WriteLine(await uniFiClient.GetFirewallPolicyOrdering(RequireSite(), zones.Data[0].Id, zones.Data[1].Id, ct));
+            }),
+            ("ACL rules", async ct => PrintPaged(await uniFiClient.ListAclRules(RequireSite(), cancellationToken: ct))),
+            ("ACL rule (first)", async ct => WriteLine(await uniFiClient.GetAclRule(RequireSite(), await FirstId(uniFiClient.ListAclRules(RequireSite(), limit: 1, cancellationToken: ct), r => r.Id), ct))),
+            ("ACL rule ordering", async ct => WriteLine(await uniFiClient.GetAclRuleOrdering(RequireSite(), ct))),
+            ("DNS policies", async ct => PrintPaged(await uniFiClient.ListDnsPolicies(RequireSite(), cancellationToken: ct))),
+            ("DNS policy (first)", async ct => WriteLine(await uniFiClient.GetDnsPolicy(RequireSite(), await FirstId(uniFiClient.ListDnsPolicies(RequireSite(), limit: 1, cancellationToken: ct), p => p.Id), ct))),
+            ("Traffic matching lists", async ct => PrintPaged(await uniFiClient.ListTrafficMatchingLists(RequireSite(), cancellationToken: ct))),
+            ("Traffic matching list (first)", async ct => WriteLine(await uniFiClient.GetTrafficMatchingList(RequireSite(), await FirstId(uniFiClient.ListTrafficMatchingLists(RequireSite(), limit: 1, cancellationToken: ct), l => l.Id), ct))),
+            ("WAN interfaces", async ct => PrintPaged(await uniFiClient.ListWanInterfaces(RequireSite(), cancellationToken: ct))),
+            ("Site-to-site VPN tunnels", async ct => PrintPaged(await uniFiClient.ListSiteToSiteVpnTunnels(RequireSite(), cancellationToken: ct))),
+            ("VPN servers", async ct => PrintPaged(await uniFiClient.ListVpnServers(RequireSite(), cancellationToken: ct))),
+            ("RADIUS profiles", async ct => PrintPaged(await uniFiClient.ListRadiusProfiles(RequireSite(), cancellationToken: ct))),
+            ("Device tags", async ct => PrintPaged(await uniFiClient.ListDeviceTags(RequireSite(), cancellationToken: ct))),
+            ("Vouchers", async ct => PrintPaged(await uniFiClient.ListVouchers(RequireSite(), cancellationToken: ct))),
+            ("DPI categories", async ct => PrintPaged(await uniFiClient.ListDpiCategories(cancellationToken: ct))),
+            ("DPI applications", async ct => PrintPaged(await uniFiClient.ListDpiApplications(cancellationToken: ct))),
+            ("Countries", async ct => PrintPaged(await uniFiClient.ListCountries(cancellationToken: ct))),
+        ];
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var title = "All Read Endpoints" + (SelectedSite is not null ? $"\nCurrent site is {SelectedSite.Name}" : "");
+            var choice = PromptOption(title, [.. entries.Select(e => e.Name)]);
+
+            if (choice == 0)
+            {
+                return;
+            }
+
+            Clear();
+            WriteLine(entries[choice - 1].Name);
+            WriteLine(new string('-', entries[choice - 1].Name.Length));
+
+            try
+            {
+                await entries[choice - 1].Run(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                WriteError($"Error: {ex.Message}");
+            }
+
+            PressAnyKeyToContinue();
+        }
+    }
+
+    private Guid RequireSite() =>
+        SelectedSite?.Id ?? throw new InvalidOperationException("No site selected. Select a site from the Sites menu first.");
+
+    private Guid RequireDevice() =>
+        SelectedDevice?.Id ?? throw new InvalidOperationException("No device selected. Select a device from the Devices menu first.");
+
+    private static async Task<Guid> FirstId<T>(Task<PagedResponse<T>> list, Func<T, Guid> id)
+    {
+        var page = await list;
+        return page.Data.Count > 0 ? id(page.Data[0]) : throw new InvalidOperationException("No items found to get by ID.");
+    }
+
+    private static void PrintPaged<T>(PagedResponse<T> page)
+    {
+        foreach (var item in page.Data)
+        {
+            WriteLine(item);
+        }
+
+        WriteLine();
+        WriteLine($"{page.Count} of {page.TotalCount} item(s) returned (offset {page.Offset}, limit {page.Limit}).");
+    }
+}

--- a/tests/UniFi.Net.TestHarness/Network/Reads.cs
+++ b/tests/UniFi.Net.TestHarness/Network/Reads.cs
@@ -70,8 +70,7 @@ public partial class NetworkClient
             }
 
             Clear();
-            WriteLine(entries[choice - 1].Name);
-            WriteLine(new string('-', entries[choice - 1].Name.Length));
+            WriteHeading(entries[choice - 1].Name);
 
             try
             {

--- a/tests/UniFi.Net.TestHarness/SiteManager/Devices.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/Devices.cs
@@ -1,21 +1,34 @@
-﻿namespace UniFi.Net.TestHarness.SiteManager;
+namespace UniFi.Net.TestHarness.SiteManager;
 
 internal partial class SiteManagerClient
 {
-	public async Task DoDevices(CancellationToken cancellationToken)
-	{
-		var devices = await client.ListDevicesAsync(cancellationToken: cancellationToken);
+    private async Task DoDevices(CancellationToken cancellationToken)
+    {
+        Clear();
+        WriteLine("Devices");
+        WriteLine("-------");
 
-		foreach (var host in devices.Data)
-		{
-			WriteLine($"Host ID: {host.HostId}");
-			foreach (var device in host.Devices)
-			{
-				WriteLine($"Device ID: {device.Ip}, Device Name: {device.Name}");
-				WriteLine(device);
-			}
-		}
+        var devices = await client.ListDevicesAsync(cancellationToken: cancellationToken);
 
-		PressAnyKeyToContinue();
-	}
+        foreach (var host in devices.Data)
+        {
+            WriteLine($"Host: {host.HostName} ({host.HostId})");
+            WriteLine($"  Updated at: {host.UpdatedAt:yyyy-MM-dd HH:mm:ss}");
+            foreach (var device in host.Devices)
+            {
+                WriteLine($"  {device.Name} [{device.ShortName}]");
+                WriteLine($"    Id:      {device.Id}");
+                WriteLine($"    MAC:     {device.Mac}, IP: {device.Ip}");
+                WriteLine($"    Product: {device.ProductLine}, Model: {device.Model}");
+                WriteLine($"    Status:  {device.Status}, Version: {device.Version}, Firmware: {device.FirmwareStatus}");
+                WriteLine($"    Console: {device.IsConsole}, Managed: {device.IsManaged}");
+                WriteLine($"    Started: {device.StartupTime?.ToString("yyyy-MM-dd HH:mm:ss") ?? "(unknown)"}, Adopted: {device.AdoptionTime?.ToString("yyyy-MM-dd HH:mm:ss") ?? "(unknown)"}");
+            }
+            WriteLine();
+        }
+
+        WriteLine($"{devices.Data.Count} host(s) returned. Next token: {devices.NextToken ?? "(none)"}");
+
+        PressAnyKeyToContinue();
+    }
 }

--- a/tests/UniFi.Net.TestHarness/SiteManager/Devices.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/Devices.cs
@@ -5,8 +5,7 @@ internal partial class SiteManagerClient
     private async Task DoDevices(CancellationToken cancellationToken)
     {
         Clear();
-        WriteLine("Devices");
-        WriteLine("-------");
+        WriteHeading("Devices");
 
         var devices = await client.ListDevicesAsync(cancellationToken: cancellationToken);
 

--- a/tests/UniFi.Net.TestHarness/SiteManager/Hosts.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/Hosts.cs
@@ -1,77 +1,54 @@
-﻿using UniFi.Net.SiteManager.Models;
+using UniFi.Net.SiteManager.Models;
 
 namespace UniFi.Net.TestHarness.SiteManager;
 
 internal partial class SiteManagerClient
 {
-    private async Task DoHosts(int? action, CancellationToken cancellationToken)
+    private async Task DoHosts(CancellationToken cancellationToken)
     {
-        switch(action)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            case 1:
-                var hosts = await client.ListHostsAsync(cancellationToken: cancellationToken);
-                PrintHostSelectionMenu(hosts.Data);
-                break;
-            case 2:
-                if (!SelectedHostCheck()) return;
-                var host = await client.GetHostAsync(SelectedHost!.Id, cancellationToken);
-                WriteLine($"{host.Data})");
-                PressAnyKeyToContinue();
-                break;
+            var action = PromptOption(Title() + "\nHosts", ["List hosts (and select)", "Get selected host by ID"]);
+
+            switch (action)
+            {
+                case 0:
+                    return;
+                case 1:
+                    var hosts = await client.ListHostsAsync(cancellationToken: cancellationToken);
+                    var selected = SelectItem("Select a host:", hosts.Data, h => $"{h.IpAddress} - {h.Type} ({h.Id})");
+                    if (selected is not null)
+                    {
+                        SelectedHost = selected;
+                    }
+                    break;
+                case 2:
+                    if (!SelectedHostCheck()) continue;
+                    var host = await client.GetHostAsync(SelectedHost!.Id, cancellationToken);
+                    PrintHost(host.Data);
+                    PressAnyKeyToContinue();
+                    break;
+            }
         }
     }
 
-    private static int PrintHostsMenu()
+    private static void PrintHost(Host host)
     {
         Clear();
-        WriteLine("1. List Hosts");
-        WriteLine("2. Get Host by ID");
-        WriteLine("3. Exit");
-        Write("Select an option: ");
-        if (Int32.TryParse(ReadKey().KeyChar.ToString(), out int choice))
-        {
-            return choice;
-        }
-
-        WriteLine("Invalid choice. Please try again.");
-        return PrintHostsMenu();
-    }
-
-    private void PrintHostSelectionMenu(IReadOnlyList<Host> hosts)
-    {
-        Clear();
-        WriteLine("Select a Host:");
-        WriteLine("-------------------------------");
-        for (int i = 0; i < hosts.Count; i++)
-        {
-            var host = hosts.ElementAt(i);
-            WriteLine($"{host.IpAddress} ({host.Id})");
-        }
-        WriteLine($"{hosts.Count + 1}. Back to Hosts Menu");
-        Write("\nSelect an option: ");
-
-        var input = ReadKey();
-
-        if (!Int32.TryParse(input.KeyChar.ToString(), out var option) || option > hosts.Count + 1)
-        {
-            WriteLine("Invalid option, please try again.");
-            PrintHostSelectionMenu(hosts);
-        }
-        else if (option < hosts.Count + 1)
-        {
-            SelectedHost = hosts[option - 1];
-            // Back to Hosts Menu
-            return;
-        }
-    }
-
-    private bool SelectedHostCheck()
-    {
-        if (SelectedHost == null)
-        {
-            WriteLine("No host selected. Please select a host first.");
-            return false;
-        }
-        return true;
+        WriteLine("Host Details");
+        WriteLine("------------");
+        WriteLine($"Id:                {host.Id}");
+        WriteLine($"Hardware Id:       {host.HardwareId}");
+        WriteLine($"Type:              {host.Type}");
+        WriteLine($"IP Address:        {host.IpAddress}");
+        WriteLine($"Owner:             {host.Owner}");
+        WriteLine($"Blocked:           {host.IsBlocked}");
+        WriteLine($"Registered:        {host.RegistrationTime:yyyy-MM-dd HH:mm:ss}");
+        WriteLine($"Last State Change: {host.LastConnectionStateChange:yyyy-MM-dd HH:mm:ss}");
+        WriteLine($"Latest Backup:     {host.LatestBackupTime:yyyy-MM-dd HH:mm:ss}");
+        WriteLine($"User:              {host.UserData.FullName} <{host.UserData.Email}> ({host.UserData.Role})");
+        WriteLine($"Apps:              {String.Join(", ", host.UserData.Apps)}");
+        WriteLine($"Controllers:       {String.Join(", ", host.UserData.Controllers)}");
+        WriteLine($"Reported State:    {(host.ReportedState is null ? "(none)" : "(present)")}");
     }
 }

--- a/tests/UniFi.Net.TestHarness/SiteManager/Hosts.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/Hosts.cs
@@ -35,8 +35,7 @@ internal partial class SiteManagerClient
     private static void PrintHost(Host host)
     {
         Clear();
-        WriteLine("Host Details");
-        WriteLine("------------");
+        WriteHeading("Host Details");
         WriteLine($"Id:                {host.Id}");
         WriteLine($"Hardware Id:       {host.HardwareId}");
         WriteLine($"Type:              {host.Type}");

--- a/tests/UniFi.Net.TestHarness/SiteManager/IspMetrics.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/IspMetrics.cs
@@ -62,8 +62,7 @@ internal partial class SiteManagerClient
 
     private static void PrintMetrics(IReadOnlyList<IspMetric> metrics)
     {
-        WriteLine("ISP Metrics");
-        WriteLine("-----------");
+        WriteHeading("ISP Metrics");
 
         foreach (var metric in metrics)
         {

--- a/tests/UniFi.Net.TestHarness/SiteManager/IspMetrics.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/IspMetrics.cs
@@ -1,24 +1,89 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UniFi.Net.SiteManager.Models;
 
 namespace UniFi.Net.TestHarness.SiteManager;
 
 internal partial class SiteManagerClient
 {
-    public int PrintIspMetricsMenu()
+    private async Task DoIspMetrics(CancellationToken cancellationToken)
     {
-        Console.WriteLine("ISP Metrics Menu:");
-        Console.WriteLine("1. List ISP Metrics");
-        Console.WriteLine("2. Get ISP Metric by ID");
-        Console.WriteLine("3. Exit");
-        if (Int32.TryParse(Console.ReadLine(), out int choice) && choice >= 1 && choice <= 3)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            return choice;
+            var action = PromptOption(
+                Title() + "\nISP Metrics",
+                [
+                    "Get 5-minute metrics (last 24 hours, by timestamp)",
+                    "Get 1-hour metrics (duration 7d)",
+                    "Query metrics for all sites (5-minute, last 24 hours)",
+                ]);
+
+            switch (action)
+            {
+                case 0:
+                    return;
+                case 1:
+                    var byTimestamp = await client.GetIspMetricsAsync(
+                        MetricInterval.FiveMinutes,
+                        DateTimeOffset.UtcNow.AddDays(-1),
+                        DateTimeOffset.UtcNow,
+                        cancellationToken);
+                    PrintMetrics(byTimestamp.Data);
+                    PressAnyKeyToContinue();
+                    break;
+                case 2:
+                    var byDuration = await client.GetIspMetricsAsync(MetricInterval.OneHour, "7d", cancellationToken);
+                    PrintMetrics(byDuration.Data);
+                    PressAnyKeyToContinue();
+                    break;
+                case 3:
+                    var sites = await client.ListSitesAsync(cancellationToken: cancellationToken);
+                    var queries = sites.Data.Select(site => new IspMetricsQuery
+                    {
+                        BeginTimestamp = DateTimeOffset.UtcNow.AddDays(-1),
+                        EndTimestamp = DateTimeOffset.UtcNow,
+                        HostId = site.HostId,
+                        SiteId = site.SiteId,
+                    }).ToList();
+
+                    if (queries.Count == 0)
+                    {
+                        WriteLine("No sites found to query.");
+                        PressAnyKeyToContinue();
+                        break;
+                    }
+
+                    var result = await client.QueryIspMetricsAsync(MetricInterval.FiveMinutes, queries, cancellationToken);
+                    WriteLine($"Status: {result.Data.Status ?? "(none)"}, Message: {result.Data.Message ?? "(none)"}");
+                    PrintMetrics(result.Data.Metrics);
+                    PressAnyKeyToContinue();
+                    break;
+            }
         }
-        Console.WriteLine("Invalid choice, please try again.");
-        return PrintIspMetricsMenu();
+    }
+
+    private static void PrintMetrics(IReadOnlyList<IspMetric> metrics)
+    {
+        WriteLine("ISP Metrics");
+        WriteLine("-----------");
+
+        foreach (var metric in metrics)
+        {
+            WriteLine($"Host: {metric.HostId}");
+            WriteLine($"  Site:    {metric.SiteId}");
+            WriteLine($"  Type:    {metric.MetricType}, Periods: {metric.Periods.Count}");
+
+            var latest = metric.Periods.OrderByDescending(p => p.MetricTime).FirstOrDefault();
+            if (latest is not null)
+            {
+                var wan = latest.Data.Wan;
+                WriteLine($"  Latest ({latest.MetricTime:yyyy-MM-dd HH:mm:ss}):");
+                WriteLine($"    ISP:       {wan.IspName} (ASN {wan.IspAsn})");
+                WriteLine($"    Download:  {wan.DownloadKbps} kbps, Upload: {wan.UploadKbps} kbps");
+                WriteLine($"    Latency:   avg {wan.AvgLatency} ms, max {wan.MaxLatency} ms");
+                WriteLine($"    Loss:      {wan.PacketLoss}%, Uptime: {wan.Uptime}, Downtime: {wan.Downtime}");
+            }
+            WriteLine();
+        }
+
+        WriteLine($"{metrics.Count} metric set(s) returned.");
     }
 }

--- a/tests/UniFi.Net.TestHarness/SiteManager/SDWanConfigs.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/SDWanConfigs.cs
@@ -58,8 +58,7 @@ internal partial class SiteManagerClient
     private static void PrintConfig(SDWanConfig config)
     {
         Clear();
-        WriteLine("SD-WAN Config");
-        WriteLine("-------------");
+        WriteHeading("SD-WAN Config");
         WriteLine($"Id:      {config.Id}");
         WriteLine($"Name:    {config.Name}");
         WriteLine($"Type:    {config.Type}");
@@ -85,8 +84,7 @@ internal partial class SiteManagerClient
     private static void PrintStatus(SDWanConfigStatus status)
     {
         Clear();
-        WriteLine("SD-WAN Config Status");
-        WriteLine("--------------------");
+        WriteHeading("SD-WAN Config Status");
         WriteLine($"Id:              {status.Id}");
         WriteLine($"Fingerprint:     {status.Fingerprint}");
         WriteLine($"Generate status: {status.GenerateStatus}");

--- a/tests/UniFi.Net.TestHarness/SiteManager/SDWanConfigs.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/SDWanConfigs.cs
@@ -1,24 +1,114 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using UniFi.Net.SiteManager.Models;
 
 namespace UniFi.Net.TestHarness.SiteManager;
+
 internal partial class SiteManagerClient
 {
-    public int PrintSDWanConfigsMenu()
+    private async Task DoSDWanConfigs(CancellationToken cancellationToken)
     {
-        Console.WriteLine("SD-WAN Configs Menu:");
-        Console.WriteLine("1. List SD-WAN Configs");
-        Console.WriteLine("2. Get SD-WAN Config Status");
-        Console.WriteLine("3. Exit");
-        Console.Write("Select an option: ");
-        if (Int32.TryParse(Console.ReadLine(), out int choice) && choice >= 1 && choice <= 3)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            return choice;
+            var action = PromptOption(
+                Title() + "\nSD-WAN Configs",
+                [
+                    "List SD-WAN configs (and select)",
+                    "Get selected SD-WAN config by ID",
+                    "Get selected SD-WAN config status",
+                ]);
+
+            switch (action)
+            {
+                case 0:
+                    return;
+                case 1:
+                    var configs = await client.ListSDWanConfigsAsync(cancellationToken);
+                    var selected = SelectItem("Select an SD-WAN config:", configs.Data, c => $"{c.Name} - {c.Type} ({c.Id})");
+                    if (selected is not null)
+                    {
+                        SelectedSDWanConfig = selected;
+                    }
+                    break;
+                case 2:
+                    if (!SelectedSDWanConfigCheck()) continue;
+                    var config = await client.GetSDWanConfigAsync(SelectedSDWanConfig!.Id, cancellationToken);
+                    PrintConfig(config.Data);
+                    PressAnyKeyToContinue();
+                    break;
+                case 3:
+                    if (!SelectedSDWanConfigCheck()) continue;
+                    var status = await client.GetSDWanConfigStatusAsync(SelectedSDWanConfig!.Id, cancellationToken);
+                    PrintStatus(status.Data);
+                    PressAnyKeyToContinue();
+                    break;
+            }
         }
-        Console.WriteLine("Invalid choice. Please try again.");
-        return PrintSDWanConfigsMenu();
+    }
+
+    private bool SelectedSDWanConfigCheck()
+    {
+        if (SelectedSDWanConfig == null)
+        {
+            WriteError("No SD-WAN config selected. Please select one first (List SD-WAN configs).");
+            PressAnyKeyToContinue();
+            return false;
+        }
+        return true;
+    }
+
+    private static void PrintConfig(SDWanConfig config)
+    {
+        Clear();
+        WriteLine("SD-WAN Config");
+        WriteLine("-------------");
+        WriteLine($"Id:      {config.Id}");
+        WriteLine($"Name:    {config.Name}");
+        WriteLine($"Type:    {config.Type}");
+        WriteLine($"Variant: {config.Variant}");
+        WriteLine($"Settings:");
+        WriteLine($"  Hubs interconnect:   {config.Settings.HubsInterconnect}");
+        WriteLine($"  Tunnels mode:        {config.Settings.SpokeToHubTunnelsMode}");
+        WriteLine($"  Routing:             {config.Settings.SpokeToHubRouting}");
+        WriteLine($"  Auto-scale and NAT:  {config.Settings.SpokesAutoScaleAndNatEnabled} ({config.Settings.SpokesAutoScaleAndNatRange})");
+        WriteLine($"  Isolate spokes:      {config.Settings.SpokesIsolate}");
+        WriteLine($"Hubs ({config.Hubs.Count}):");
+        foreach (var hub in config.Hubs)
+        {
+            WriteLine($"  {hub.Id}: site {hub.SiteId}, primary WAN {hub.PrimaryWan}, failover {hub.WanFailover}");
+        }
+        WriteLine($"Spokes ({config.Spokes.Count}):");
+        foreach (var spoke in config.Spokes)
+        {
+            WriteLine($"  {spoke.Id}: site {spoke.SiteId}, primary WAN {spoke.PrimaryWan}, failover {spoke.WanFailover}");
+        }
+    }
+
+    private static void PrintStatus(SDWanConfigStatus status)
+    {
+        Clear();
+        WriteLine("SD-WAN Config Status");
+        WriteLine("--------------------");
+        WriteLine($"Id:              {status.Id}");
+        WriteLine($"Fingerprint:     {status.Fingerprint}");
+        WriteLine($"Generate status: {status.GenerateStatus}");
+        WriteLine($"Updated at:      {DateTimeOffset.FromUnixTimeSeconds(status.UpdatedAt):yyyy-MM-dd HH:mm:ss}");
+        WriteLine($"Errors:          {(status.Errors.Count > 0 ? String.Join("; ", status.Errors) : "(none)")}");
+        WriteLine($"Warnings:        {(status.Warnings.Count > 0 ? String.Join("; ", status.Warnings) : "(none)")}");
+        WriteLine($"Hubs ({status.Hubs.Count}):");
+        foreach (var hub in status.Hubs)
+        {
+            WriteLine($"  {hub.Name}: apply {hub.ApplyStatus}, primary WAN {hub.PrimaryWanStatus?.Ip} ({hub.PrimaryWanStatus?.Latency} ms)");
+        }
+        WriteLine($"Spokes ({status.Spokes.Count}):");
+        foreach (var spoke in status.Spokes)
+        {
+            WriteLine($"  {spoke.Name}: apply {spoke.ApplyStatus}, primary WAN {spoke.PrimaryWanStatus?.Ip} ({spoke.PrimaryWanStatus?.Latency} ms)");
+            foreach (var connection in spoke.Connections)
+            {
+                foreach (var tunnel in connection.Tunnels)
+                {
+                    WriteLine($"    Tunnel to hub {connection.HubId}: {tunnel.SpokeWanId} -> {tunnel.HubWanId} ({tunnel.Status})");
+                }
+            }
+        }
     }
 }

--- a/tests/UniFi.Net.TestHarness/SiteManager/SiteManagerClient.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/SiteManagerClient.cs
@@ -1,4 +1,4 @@
-﻿using UniFi.Net.SiteManager;
+using UniFi.Net.SiteManager;
 using UniFi.Net.SiteManager.Models;
 
 namespace UniFi.Net.TestHarness.SiteManager;
@@ -7,56 +7,72 @@ internal partial class SiteManagerClient(ISiteManagerClient client)
 {
     private Host? SelectedHost { get; set; }
 
+    private BasicSDWanConfig? SelectedSDWanConfig { get; set; }
+
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        var hosts = await client.ListHostsAsync(cancellationToken: cancellationToken);
-
-        SelectedHost = hosts.Data.Count > 0 ? hosts.Data[0] : null;
-
-        (int Primary, int? Secondary) action = (0, null);
-        while (action.Primary != 5 && !cancellationToken.IsCancellationRequested)
+        try
         {
-            action = PrintMenu();
+            var hosts = await client.ListHostsAsync(cancellationToken: cancellationToken);
+            SelectedHost = hosts.Data.Count > 0 ? hosts.Data[0] : null;
+        }
+        catch (Exception ex)
+        {
+            WriteError($"Could not list hosts: {ex.Message}");
+            PressAnyKeyToContinue();
+        }
 
-            await DoAction(action, cancellationToken);
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var action = PromptOption(Title(), ["Hosts", "Sites", "Devices", "ISP Metrics", "SD-WAN Configs"], "Main menu");
+
+            if (action == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                await (action switch
+                {
+                    1 => DoHosts(cancellationToken),
+                    2 => DoSites(cancellationToken),
+                    3 => DoDevices(cancellationToken),
+                    4 => DoIspMetrics(cancellationToken),
+                    5 => DoSDWanConfigs(cancellationToken),
+                    _ => Task.CompletedTask,
+                });
+            }
+            catch (Exception ex)
+            {
+                WriteError($"Error: {ex.Message}");
+                PressAnyKeyToContinue();
+            }
         }
     }
 
-    private Task DoAction((int Primary, int? Secondary) action, CancellationToken cancellationToken) =>
-        action.Primary switch
-        {
-            1 => DoHosts(action.Secondary, cancellationToken),
-            2 => DoSites(cancellationToken),
-            3 => DoDevices(cancellationToken),
-            _ => Task.CompletedTask,
-        };
-
-    private (int Primary, int? Secondary) PrintMenu()
+    private string Title()
     {
-        Clear();
-        WriteLine("Unifi Site Manager Client Test Harness");
-        WriteLine("-------------------------");
-        WriteLine("1. Hosts");
-        WriteLine("2. Sites");
-        WriteLine("3. Devices");
-        WriteLine("4. ISP Metrics");
-        WriteLine("5. SD-WAN Configs");
-        WriteLine("6. Main menu");
-        Write("Select an option: ");
-
-        var input = ReadKey();
-        WriteLine();
-
-        return input.KeyChar switch
+        var title = "UniFi Site Manager Test Harness";
+        if (SelectedHost is not null)
         {
-            '1' => (1, PrintHostsMenu()),
-            '2' => (2, null), // List Devices
-            '3' => (3, null), // Get Device Details
-            '4' => (4, PrintIspMetricsMenu()), // List Clients
-            '5' => (5, PrintSDWanConfigsMenu()), // Exit
-            '6' => (6, null), // Exit
-            _ => (-1, null)
-        };
+            title += $"\nCurrent host is {SelectedHost.IpAddress} ({SelectedHost.Type})";
+        }
+        if (SelectedSDWanConfig is not null)
+        {
+            title += $"\nCurrent SD-WAN config is {SelectedSDWanConfig.Name}";
+        }
+        return title;
+    }
+
+    private bool SelectedHostCheck()
+    {
+        if (SelectedHost == null)
+        {
+            WriteError("No host selected. Please select a host first (Hosts > List hosts).");
+            PressAnyKeyToContinue();
+            return false;
+        }
+        return true;
     }
 }
-

--- a/tests/UniFi.Net.TestHarness/SiteManager/Sites.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/Sites.cs
@@ -1,15 +1,30 @@
-﻿namespace UniFi.Net.TestHarness.SiteManager;
+namespace UniFi.Net.TestHarness.SiteManager;
 
 internal partial class SiteManagerClient
 {
-    public async Task DoSites(CancellationToken cancellationToken)
+    private async Task DoSites(CancellationToken cancellationToken)
     {
+        Clear();
+        WriteLine("Sites");
+        WriteLine("-----");
+
         var sites = await client.ListSitesAsync(cancellationToken: cancellationToken);
 
         foreach (var site in sites.Data)
         {
-            WriteLine($"Site ID: {site.SiteId}, Site Name: {site.Meta.Name}");
+            WriteLine($"Site: {site.Meta.Name} ({site.SiteId})");
+            WriteLine($"  Description: {site.Meta.Desc}");
+            WriteLine($"  Host:        {site.HostId}");
+            WriteLine($"  Gateway:     {site.Statistics.Gateway?.Shortname} ({site.Meta.GatewayMac})");
+            WriteLine($"  Time zone:   {site.Meta.TimeZone}");
+            WriteLine($"  ISP:         {site.Statistics.IspInfo?.Name} ({site.Statistics.IspInfo?.Organization})");
+            WriteLine($"  Permission:  {site.Permission} (owner: {site.IsOwner})");
+            WriteLine($"  Counts:      {String.Join(", ", site.Statistics.Counts.Select(kvp => $"{kvp.Key}={kvp.Value}"))}");
+            WriteLine($"  Percentages: {String.Join(", ", site.Statistics.Percentages.Select(kvp => $"{kvp.Key}={kvp.Value}"))}");
+            WriteLine();
         }
+
+        WriteLine($"{sites.Data.Count} site(s) returned. Next token: {sites.NextToken ?? "(none)"}");
 
         PressAnyKeyToContinue();
     }

--- a/tests/UniFi.Net.TestHarness/SiteManager/Sites.cs
+++ b/tests/UniFi.Net.TestHarness/SiteManager/Sites.cs
@@ -5,8 +5,7 @@ internal partial class SiteManagerClient
     private async Task DoSites(CancellationToken cancellationToken)
     {
         Clear();
-        WriteLine("Sites");
-        WriteLine("-----");
+        WriteHeading("Sites");
 
         var sites = await client.ListSitesAsync(cancellationToken: cancellationToken);
 


### PR DESCRIPTION
## Summary

Brings `UniFi.Net.SiteManager` to releasable v1.0.0 parity ([spec](https://developer.ui.com/site-manager/v1.0.0/gettingstarted)). The endpoint surface was already complete, but a code-vs-spec diff surfaced several latent bugs that made most endpoints unusable, plus gaps in testing, packaging, and CI.

## Bug fixes (all verified against the official OpenAPI spec)

- **`ea/` prefix leftovers**: ISP metrics and SD-WAN endpoints still called the removed early-access paths; now `v1/`.
- **Metric interval path**: `/isp-metrics/FiveMinutes` → `/isp-metrics/5m` (and `1h`).
- **Paging param**: `ListHostsAsync`/`ListSitesAsync` sent `page=` instead of `pageSize=`.
- **`QueryIspMetricsAsync`**: posted a bare JSON array instead of `{ "sites": [...] }`, and declared the response as a bare array when the spec wraps it in `data.metrics` — now returns `DataResponse<IspMetricsQueryResult>`.
- **Snake_case fields**: `download_kbps`/`upload_kbps` silently deserialized to 0; mapped via `JsonPropertyName`.
- **SD-WAN enums**: `variant`, `spokeToHubTunnelsMode`, `spokeToHubRouting`, `applyStatus`, tunnel `status` are camelCase strings on the wire with no converter — every SD-WAN config/status call would have thrown. Added `CamelCaseEnumConverter` to `UniFi.Net.Core` and applied it; spoke `ApplyStatus` now uses the enum like the hub.
- **API shape**: removed the ambiguous `GetIspMetricsAsync(type)` overload pair (`duration` is now required), removed unused `ListHostsResponse`, dead debug line, restored full XML docs.

## Hardening

- **Tests**: new `UniFi.Net.SiteManager.Tests` — 10 deserialization tests using spec-shaped JSON with web defaults, including regressions for the kbps and enum fixes.
- **csproj**: multi-targets net8.0/net9.0/net10.0 with framework-matched package versions (was: 9.0.5 packages on a net8.0 target), portable symbols, `EnablePackageValidation`.
- **CI/release**: `sitemanager-ci.yml` + `sitemanager-release.yml` mirroring the hardened Network pipelines (SHA-pinned actions, least privilege, build-once/no-rebuild publish, NuGet Trusted Publishing via OIDC, `nuget.org` protected environment). CI is path-filtered; stable releases anchor to `sitemanager-v*` tags.

Breaking signature changes are safe: the package has never been published to nuget.org.

## Test plan

- [x] `dotnet build` clean across net8.0/net9.0/net10.0 — 0 warnings
- [x] `dotnet test` — 10/10 SiteManager + 17/17 Network unit tests pass
- [x] `dotnet pack` succeeds with package validation enabled
- [x] Trusted Publishing policy for `sitemanager-release.yml` to be added on nuget.org (owner action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)